### PR TITLE
Add more constructors to allow to compactly build trees

### DIFF
--- a/opencog/util/Counter.h
+++ b/opencog/util/Counter.h
@@ -117,7 +117,6 @@ public:
         return key;
     }
 
-    
     //! add 2 counters,
     /**
      * for example


### PR DESCRIPTION
for instance
```
tree<T>(root, {tree<T>(child-1, {grandchild-1, grandchild-2}), child-2})
```
builds
```
              root
              /  \
        child-1  child-2
        /    \
grandchild-1 grandchild-2
```
