### PR TITLE
type warning fix on OSX

### DIFF
--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -419,7 +419,7 @@ void Logger::log(Logger::Level level, const std::string &txt)
         gmtime_r(&t, &stm);
         strftime(timestamp, sizeof(timestamp), "%F %T", &stm);
         snprintf(timestampStr, sizeof(timestampStr),
-                "[%s:%03ld] ",timestamp, stv.tv_usec / 1000);
+                "[%s:%03ld] ",timestamp, (long)stv.tv_usec / 1000);
         oss << timestampStr;
     }
 


### PR DESCRIPTION
```
.../cogutil/opencog/util/Logger.cc:422:60: warning: format '%ld' expects argument of type 'long int', but argument 5 has type '__darwin_suseconds_t {aka int}' [-Wformat]
                 "[%s:%03ld] ",timestamp, stv.tv_usec / 1000);
                                          ~~~~~~~~~~~~~~~~~~^
```
Added explicit cast to long to ensure proper processing.