### PR TITLE
#85 - segmentation fault in debug mode on attempt to log stack trace

### DIFF
--- a/opencog/util/backtrace-symbols.c
+++ b/opencog/util/backtrace-symbols.c
@@ -198,10 +198,10 @@ static char** translate_addresses_buf(bfd * abfd, bfd_vma *addr, int naddr, asym
 
 static char **process_file(const char *file_name, bfd_vma *addr, int naddr)
 {
-      bfd *abfd;
-      char **matching;
-      char **ret_buf;
-      asymbol **syms;      /* Symbol table */
+      bfd *abfd = NULL;
+      char **matching = NULL;
+      char **ret_buf = NULL;
+      asymbol **syms = NULL;      /* Symbol table */
 
       abfd = bfd_openr(file_name, NULL);
 


### PR DESCRIPTION
#85 is fixed.
Actually I noticed this fault when Opencog test failed in debug on my Ubuntu.