### PR TITLE
Add empty_string const static

### DIFF
--- a/opencog/util/CMakeLists.txt
+++ b/opencog/util/CMakeLists.txt
@@ -119,6 +119,7 @@ INSTALL(FILES
 	StringTokenizer.h
 	tbb.h
 	tree.h
+        empty_string.h
 	DESTINATION "include/opencog/util"
 )
 

--- a/opencog/util/empty_string.h
+++ b/opencog/util/empty_string.h
@@ -1,0 +1,42 @@
+/*
+ * empty_string.h
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * The solve purpose of this file is to contain a static empty
+ * std::string whenever it is needed (which turns out to be
+ * often). Beside that it useful so that oc_to_string (pretty printer
+ * for OpenCog C++ objects) can be called with an empty initial
+ * indentation within gdb, since the latter isn't able to allocate an
+ * empty string.
+ */
+
+#include <string>
+
+#ifndef _OPENCOG_EMPTY_STRING_H_
+#define _OPENCOG_EMPTY_STRING_H_
+
+namespace opencog {
+
+const static std::string empty_string = "";
+
+} // ~namespace opencog
+
+#endif


### PR DESCRIPTION
This is meants to be used when calling oc_to_string in gdb as a work
around for gdb bug with C++11 ABI and overload resolution.