### PR TITLE
Work in progress for issue #118. Take 1.

### DIFF
--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -156,13 +156,11 @@ Logger::~Logger()
 
 void Logger::start_write_loop()
 {
+    std::unique_lock<std::mutex> lock(the_mutex);
+    if (!writingLoopActive)
     {
-        std::unique_lock<std::mutex> lock(the_mutex);
-        if (!writingLoopActive)
-        {
-            writingLoopActive = true;
-            writer_thread = std::thread(&Logger::writing_loop, this);
-        }
+        writingLoopActive = true;
+        writer_thread = std::thread(&Logger::writing_loop, this);
     }
 }
 

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -255,8 +255,7 @@ void Logger::write_msg(const std::string &msg)
     // Write to file.
     errno = 0;
     rv = fprintf(logfile, "%s", msg.c_str());
-    
-    if (rv != (int)(msg.length() + 1))
+    if (rv != (int)msg.length())
     {
     	  fprintf(stderr,
     	  			 "fprintf returned error: %s\n",

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -160,7 +160,7 @@ public:
      * synchronous logging might slow down your program).
      */
     void set_sync_flag(bool);
-
+    
     /**
      * Set the main logger to print only
      * error level log on stdout (useful when one is only interested

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -315,6 +315,9 @@ private:
     bool syncEnabled;
     FILE *logfile;
 
+    std::mutex sync_threads_mutex;
+    unsigned int logger_message_count = 0;
+
     /** One single thread does all writing of log messages */
     std::thread writer_thread;
     std::mutex the_mutex;

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -147,7 +147,7 @@ public:
     void set_print_to_stdout_flag(bool);
 
     /**
-     * If set, the logging level is preinted as a part
+     * If set, the logging level is printed as a part
      * of the message,
      */
     void set_print_level_flag(bool);
@@ -160,7 +160,7 @@ public:
      * synchronous logging might slow down your program).
      */
     void set_sync_flag(bool);
-    
+
     /**
      * Set the main logger to print only
      * error level log on stdout (useful when one is only interested

--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -254,19 +254,19 @@ public:
         TS_ASSERT_EQUALS(logger().get_filename(), my_logger.get_filename());
 
         std::string gibberish(randstr("", 10000));
-        std::string message("message");
+        std::string message("message_1");
         std::string prefix("[DEBUG] [LoggerUTest] ");
 
         logger().debug(gibberish);
-        logger().flush();       // Remove to trigger the bug
         my_logger.debug(message);
 
         logger().flush();
         my_logger.flush();
 
         std::string resline = getLastLineFromFile(my_logger.get_filename());
-        std::cout << "Length of the last line in second logger " <<
-            resline.length() << std::endl;
+        std::cout << "Length of the last line in second logger: " <<
+            resline.length() <<
+            ", Last line: <" << resline << ">" << std::endl;
 
         TS_ASSERT(resline.length() == (prefix.length() + message.length()));
         TS_ASSERT(resline == (prefix + message));

--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -33,6 +33,8 @@
 #include <atomic>
 #include <thread>
 
+#include <errno.h>
+
 #include <opencog/util/Logger.h>
 #include <opencog/util/random.h>
 
@@ -52,12 +54,14 @@ public:
 
     static std::string getLastLineFromFile(const std::string& filename) {
         std::ifstream logfile(filename);
-        std::string line, resline;
+        std::string line = {}, resline = {};
         if (logfile.is_open())
         {
             while (logfile.good())
             {
+            	 line = {};
                 getline(logfile, line);
+                
                 if (!line.empty())
                     resline = line;
             }
@@ -141,7 +145,7 @@ public:
         _logger.flush();
 
         // Hmm. I don't get it. Logger::flush calls fdatasync(),
-        // appearently this is not enough to prevent a race condition
+        // apparently this is not enough to prevent a race condition
         // between the logger write, and the read to count the lines.
         // I really don't get it .. the fdatasync should have been enough.
         // To work around this, force a sync() below to avoid spurious
@@ -246,15 +250,14 @@ public:
     void testLoggerInteraction() {
         logger().set_level(Logger::DEBUG);
         logger().set_timestamp_flag(false);
-        Logger my_logger;
-        my_logger.set_level(Logger::DEBUG);
-        my_logger.set_component("LoggerUTest");
-        my_logger.set_timestamp_flag(false);
+        logger().set_component("LoggerUTest");
 
+        Logger my_logger(logger());
+        
         // Make sure both loggers point to the same file (not really
         // part of the test but better be safe than sorry)
         TS_ASSERT_EQUALS(logger().get_filename(), my_logger.get_filename());
-
+        
         std::string gibberish(randstr("", 10000));
         std::string message("message");
         std::string prefix("[DEBUG] [LoggerUTest] ");
@@ -267,9 +270,10 @@ public:
         my_logger.flush();
 
         std::string resline = getLastLineFromFile(my_logger.get_filename());
-        std::cout << "resline = " << resline << std::endl;
-
-        TS_ASSERT(resline == prefix + message or resline == prefix + gibberish);
+        std::cout << " resline length " << resline.length() << std::endl;
+        
+		  TS_ASSERT(resline.length() == (prefix.length() + message.length()));
+        TS_ASSERT(resline == (prefix + message));
     }
 
 }; // class

--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -265,7 +265,7 @@ public:
         my_logger.flush();
 
         std::string resline = getLastLineFromFile(my_logger.get_filename());
-        std::cout << "Last line length, second logger " <<
+        std::cout << "Length of the last line in second logger " <<
             resline.length() << std::endl;
 
         TS_ASSERT(resline.length() == (prefix.length() + message.length()));

--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -33,8 +33,6 @@
 #include <atomic>
 #include <thread>
 
-#include <errno.h>
-
 #include <opencog/util/Logger.h>
 #include <opencog/util/random.h>
 
@@ -59,9 +57,8 @@ public:
         {
             while (logfile.good())
             {
-            	 line = {};
+                line = {};
                 getline(logfile, line);
-                
                 if (!line.empty())
                     resline = line;
             }
@@ -251,13 +248,11 @@ public:
         logger().set_level(Logger::DEBUG);
         logger().set_timestamp_flag(false);
         logger().set_component("LoggerUTest");
-
         Logger my_logger(logger());
-        
         // Make sure both loggers point to the same file (not really
         // part of the test but better be safe than sorry)
         TS_ASSERT_EQUALS(logger().get_filename(), my_logger.get_filename());
-        
+
         std::string gibberish(randstr("", 10000));
         std::string message("message");
         std::string prefix("[DEBUG] [LoggerUTest] ");
@@ -270,9 +265,10 @@ public:
         my_logger.flush();
 
         std::string resline = getLastLineFromFile(my_logger.get_filename());
-        std::cout << " resline length " << resline.length() << std::endl;
-        
-		  TS_ASSERT(resline.length() == (prefix.length() + message.length()));
+        std::cout << "Last line length, second logger " <<
+            resline.length() << std::endl;
+
+        TS_ASSERT(resline.length() == (prefix.length() + message.length()));
         TS_ASSERT(resline == (prefix + message));
     }
 


### PR DESCRIPTION
- Added few error checkings.
- Fixed test code to execute correct checks, via TS_ASSERT under testLoggerInteraction(), /tests/util/LoggerUTest.cxxtest file
- Completed all paths to handle mutex while accesing logfile
- Added constructor method for Logger::Logger(const Logger& log)
- Need to follow up on some interactions between cout and logger
- Also need to fix white spaces and tabs next.
