### PR TITLE
move cmake files to lib/cmake/CogUtil (fix for #126)

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -43,9 +43,11 @@ INSTALL(FILES
 set(INCLUDE_INSTALL_DIR include/ )
 set(LIB_INSTALL_DIR lib/ )
 
+set(COGUTIL_CMAKE_DIR lib/cmake/CogUtil)
+
 include(CMakePackageConfigHelpers)
 configure_package_config_file(CogUtilConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/CogUtilConfig.cmake
-                              INSTALL_DESTINATION ${LIB_INSTALL_DIR}/CogUtil/cmake
+                              INSTALL_DESTINATION COGUTIL_CMAKE_DIR
                               PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
 
 write_basic_package_version_file(
@@ -58,5 +60,5 @@ INSTALL(FILES
        ${CMAKE_CURRENT_BINARY_DIR}/CogUtilConfigVersion.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/CogUtilConfig.cmake
        DESTINATION
-       ${LIB_INSTALL_DIR}/CogUtil/cmake)
+       ${COGUTIL_CMAKE_DIR})
 


### PR DESCRIPTION
Moving cmake files to ${LIB_INSTALL_DIR}/cmake/CogUtil for consistency with atomspace and opencog. See issue #126 