### PR TITLE
Single-queue message writing

### DIFF
--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -448,14 +448,14 @@ void Logger::log(Logger::Level level, const std::string &txt)
 
     oss << txt << std::endl;
 
+#ifndef CYGWIN
     if (level <= backTraceLevel)
     {
-#ifndef CYGWIN
         prt_backtrace(oss);
-#endif
     }
+#endif
 
-    _log_writer.qmsg(new std::string(oss.str()));
+    _log_writer.qmsg(oss.str());
 
     // If the queue gets too full, block until it's flushed to file or
     // stdout. This can sometimes happen, if some component is spewing
@@ -479,7 +479,7 @@ void Logger::backtrace()
     prt_backtrace(oss);
     #endif
 
-    _log_writer.qmsg(new std::string(oss.str()));
+    _log_writer.qmsg(oss.str());
 
     // If the queue gets too full, block until it's flushed to file or
     // stdout. This can sometimes happen, if some component is spewing

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -147,7 +147,7 @@ Logger::~Logger()
     _log_writer.flush();
 }
 
-// Logger::LogWriter _log_writer;
+Logger::LogWriter Logger::_log_writer;
 
 Logger::LogWriter::LogWriter(void)
 {

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -157,8 +157,6 @@ Logger::LogWriter::LogWriter(void)
 #endif
     logfile = NULL;
     pending_write = false;
-
-    start_write_loop();
 }
 
 Logger::LogWriter::~LogWriter()
@@ -249,11 +247,10 @@ void Logger::LogWriter::write_msg(const std::string &msg)
             fprintf(stderr, "[ERROR] Unable to open log file \"%s\"\n",
                     fileName.c_str());
             lock.unlock();
-            // disable();
+            stop_write_loop();
             return;
         }
-
-        // enable();
+        start_write_loop();
     }
 
     // Write to file.
@@ -351,6 +348,9 @@ void Logger::LogWriter::setFileName(const std::string& s)
         fclose(logfile);
     }
     logfile = NULL;
+
+    lock.unlock();
+    start_write_loop();
 }
 
 void Logger::set_filename(const std::string& s)

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -157,15 +157,18 @@ Logger::LogWriter::LogWriter(void)
 #endif
     logfile = NULL;
     pending_write = false;
+
+    start_write_loop();
 }
 
 Logger::LogWriter::~LogWriter()
 {
+    if (logfile == NULL) return;
+
     // Wait for queue to empty
     flush();
     stop_write_loop();
-
-    if (logfile != NULL) fclose(logfile);
+    fclose(logfile);
 }
 
 void Logger::LogWriter::start_write_loop()

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -273,15 +273,7 @@ void Logger::LogWriter::write_msg(const std::string &msg)
 Logger::Logger(const std::string &fname, Logger::Level level, bool tsEnabled)
     : error(*this), warn(*this), info(*this), debug(*this), fine(*this)
 {
-    try {
-        _log_writer = _loggers.at(fname);
-    }
-    catch (...) {
-        _log_writer = new LogWriter();
-        _log_writer->printToStdout = false;
-        _log_writer->setFileName(fname);
-        _loggers[fname] = _log_writer;
-    }
+    set_filename(fname);
 
     this->currentLevel = level;
     this->backTraceLevel = ERROR;

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -250,7 +250,6 @@ void Logger::LogWriter::write_msg(const std::string &msg)
             stop_write_loop();
             return;
         }
-        start_write_loop();
     }
 
     // Write to file.
@@ -274,8 +273,8 @@ void Logger::LogWriter::write_msg(const std::string &msg)
 Logger::Logger(const std::string &fname, Logger::Level level, bool tsEnabled)
     : error(*this), warn(*this), info(*this), debug(*this), fine(*this)
 {
-    _log_writer.setFileName(fname);
     _log_writer.printToStdout = false;
+    _log_writer.setFileName(fname);
 
     this->currentLevel = level;
     this->backTraceLevel = ERROR;

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -28,6 +28,7 @@
 #define _OPENCOG_LOGGER_H
 
 #include <cstdarg>
+#include <map>
 #include <mutex>
 #include <sstream>
 #include <string>
@@ -361,8 +362,8 @@ private:
         void flush();
     };
 
-    // Singleton instance.
-    static LogWriter _log_writer;
+    LogWriter* _log_writer;
+    static std::map<std::string, LogWriter*> _loggers;
 
 }; // class
 

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -41,11 +41,10 @@ namespace opencog
  *  @{
  */
 
-//! logging evens
+//! logging events
 class Logger
 {
     void set(const Logger&);
-    bool writingLoopActive;
 public:
 
     // WARNING: if you change the levels don't forget to update
@@ -303,30 +302,14 @@ public:
 
 private:
 
-    std::string fileName;
     std::string component;
     Level currentLevel;
     Level backTraceLevel;
     bool timestampEnabled;
     bool threadIdEnabled;
     bool logEnabled;
-    bool printToStdout;
     bool printLevel;
     bool syncEnabled;
-    FILE *logfile;
-
-    /** One single thread does all writing of log messages */
-    std::thread writer_thread;
-    std::mutex the_mutex;
-
-    /** Queue for log messages */
-    concurrent_queue< std::string* > msg_queue;
-    bool pending_write;
-
-    void start_write_loop();
-    void stop_write_loop();
-    void writing_loop();
-    void write_msg(const std::string &msg);
 
     /**
      * Enable logging messages.
@@ -338,9 +321,51 @@ private:
      */
     void disable();
 
+    class LogWriter
+    {
+        /* One writer per file */
+        std::string fileName;
+        FILE *logfile;
+        bool writingLoopActive;
+
+        /** One single thread does all writing of log messages */
+        std::thread writer_thread;
+        std::mutex the_mutex;
+
+        /** Queue for log messages */
+        concurrent_queue< std::string* > msg_queue;
+        bool pending_write;
+
+        void start_write_loop();
+        void stop_write_loop();
+        void writing_loop();
+        void write_msg(const std::string&);
+
+    public:
+        bool printToStdout;
+
+        LogWriter(void);
+        ~LogWriter();
+
+        void setFileName(const std::string&);
+
+        const std::string& getFileName(void) const
+            { return fileName; }
+
+        void qmsg(std::string* str)
+            { msg_queue.push(str); }
+
+        size_t size(void)
+            { return msg_queue.size(); }
+
+        void flush();
+    };
+
+    static LogWriter _log_writer;
+
 }; // class
 
-// singleton instance (following Meyer's design pattern)
+// A singleton instance is enough for most users.
 Logger& logger();
 
 // Macros to not evaluate the stream if log level is disabled

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -361,6 +361,7 @@ private:
         void flush();
     };
 
+    // Singleton instance.
     static LogWriter _log_writer;
 
 }; // class

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -352,8 +352,8 @@ private:
         const std::string& getFileName(void) const
             { return fileName; }
 
-        void qmsg(std::string* str)
-            { msg_queue.push(str); }
+        void qmsg(const std::string& str)
+            { msg_queue.push(new std::string(str)); }
 
         size_t size(void)
             { return msg_queue.size(); }

--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -260,7 +260,6 @@ public:
         std::string prefix("[DEBUG] [LoggerUTest] ");
 
         logger().debug(gibberish);
-        logger().flush();       // Remove to trigger the bug
         my_logger.debug(message);
 
         logger().flush();

--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -268,7 +268,7 @@ public:
         std::string resline = getLastLineFromFile(my_logger.get_filename());
         std::cout << "resline = " << resline << std::endl;
 
-        TS_ASSERT(resline == prefix + message or resline == prefix + gibberish);
+        TS_ASSERT(resline == prefix + message);
     }
 
 }; // class


### PR DESCRIPTION
Allow the use of multiple loggers, with one message queue per filename.

This is intended to fix issues discussed in #127 