### PR TITLE
White space fix

### DIFF
--- a/opencog/util/Counter.h
+++ b/opencog/util/Counter.h
@@ -49,190 +49,190 @@ using boost::adaptors::map_values;
  */
 template<typename T, typename CT, typename CMP = std::less<T>>
 class Counter : public std::map<T, CT, CMP>
-    , boost::arithmetic<Counter<T, CT, CMP>>
-    , boost::arithmetic2<Counter<T, CT, CMP>,CT>
+	, boost::arithmetic<Counter<T, CT, CMP>>
+	, boost::arithmetic2<Counter<T, CT, CMP>,CT>
 
 {
 protected:
-    /** @todo this will be replaced by C++11 constructor
-     * delegation instead of init
-     */
-    template<typename IT>
-    void init(IT from, IT to) {
-        while(from != to) {
-            this->operator[](*from) += 1;  // we don't use ++ to put the
-                                           // least assumption on on CT
-            ++from;
-        }
-    }
+	/** @todo this will be replaced by C++11 constructor
+	 * delegation instead of init
+	 */
+	template<typename IT>
+	void init(IT from, IT to) {
+		while(from != to) {
+			this->operator[](*from) += 1;  // we don't use ++ to put the
+										   // least assumption on on CT
+			++from;
+		}
+	}
 
 public:
-    typedef std::map<T, CT, CMP> super;
-    typedef typename super::value_type value_type;
+	typedef std::map<T, CT, CMP> super;
+	typedef typename super::value_type value_type;
 
-    Counter() {}
+	Counter() {}
 
-    template<typename IT>
-    Counter(IT from, IT to)
-    {
-        init(from, to);
-    }
+	template<typename IT>
+	Counter(IT from, IT to)
+	{
+		init(from, to);
+	}
 
-    template<typename Container>
-    Counter(const Container& c)
-    {
-        init(c.begin(), c.end());
-    }
+	template<typename Container>
+	Counter(const Container& c)
+	{
+		init(c.begin(), c.end());
+	}
 
-    Counter(const std::initializer_list<value_type>& il)
-    {
-        for(const auto& v : il)
-            this->operator[](v.first) = v.second;
-    }
+	Counter(const std::initializer_list<value_type>& il)
+	{
+		for(const auto& v : il)
+			this->operator[](v.first) = v.second;
+	}
 
-    /// Return the count of a key, possibly returning a default if none
-    /// is present. That method different that operator[] because it
-    /// doesn't insert the element if it is not present. This is very
-    /// useful for multi-threading programming, by helping avoid race
-    /// conditions.
-    CT get(const T& key, CT c = CT()) const
-    {
-        typename super::const_iterator it = this->find(key);
-        return it == this->cend()? c : it->second;
-    }
+	/// Return the count of a key, possibly returning a default if none
+	/// is present. That method different that operator[] because it
+	/// doesn't insert the element if it is not present. This is very
+	/// useful for multi-threading programming, by helping avoid race
+	/// conditions.
+	CT get(const T& key, CT c = CT()) const
+	{
+		typename super::const_iterator it = this->find(key);
+		return it == this->cend()? c : it->second;
+	}
 
-    //! Return the total of all counted elements
-    CT total_count() const
-    {
-        return boost::accumulate(*this | map_values, (CT)0);
-    }
+	//! Return the total of all counted elements
+	CT total_count() const
+	{
+		return boost::accumulate(*this | map_values, (CT)0);
+	}
 
-    //! Return the mode, the element that occurs most frequently
-    T mode() const
-    {
-        T key = super::begin()->first;
-        CT cnt = super::begin()->second;
-        for (const auto& v : *this) {
-            if (cnt < v.second)
-                key = v.first;
-        }
-        return key;
-    }
+	//! Return the mode, the element that occurs most frequently
+	T mode() const
+	{
+		T key = super::begin()->first;
+		CT cnt = super::begin()->second;
+		for (const auto& v : *this) {
+			if (cnt < v.second)
+				key = v.first;
+		}
+		return key;
+	}
 
 	/* Counter operators:
 	 * examples with:
-     * c1 = {'a':1, 'b':2}
-     * c2 = {'b':2, 'c':3}
+	 * c1 = {'a':1, 'b':2}
+	 * c2 = {'b':2, 'c':3}
 	 * v = 2
 	 */
 
-    //! add 2 counters,
-    /**
-     * c1 += c2
-     * =>
-     * c1 = {'a':1, 'b':4, 'c':3}
-     */
-    Counter& operator+=(const Counter& other) {
-        for (const auto& v : other)
-            this->operator[](v.first) += v.second;
-        return *this;
-    }
+	//! add 2 counters,
+	/**
+	 * c1 += c2
+	 * =>
+	 * c1 = {'a':1, 'b':4, 'c':3}
+	 */
+	Counter& operator+=(const Counter& other) {
+		for (const auto& v : other)
+			this->operator[](v.first) += v.second;
+		return *this;
+	}
 
 	//! subtract 2 counters,
-    /**
-     * c1 -= c2
-     * =>
-     * c1 = {'a':1, 'b':0, 'c':-3}
-     */
-    Counter& operator-=(const Counter& other) {
-        for (const auto& v : other)
-            this->operator[](v.first) -= v.second;
-        return *this;
-    }
+	/**
+	 * c1 -= c2
+	 * =>
+	 * c1 = {'a':1, 'b':0, 'c':-3}
+	 */
+	Counter& operator-=(const Counter& other) {
+		for (const auto& v : other)
+			this->operator[](v.first) -= v.second;
+		return *this;
+	}
 
 	//! multiply 2 counters,
-    /**
-     * c1 *= c2
-     * =>
-     * c1 = {'a':1, 'b':4, 'c':0}
-     */
-    Counter& operator*=(const Counter& other) {
-        for (const auto& v : other)
-            this->operator[](v.first) *= v.second;
-        return *this;
-    }
+	/**
+	 * c1 *= c2
+	 * =>
+	 * c1 = {'a':1, 'b':4, 'c':0}
+	 */
+	Counter& operator*=(const Counter& other) {
+		for (const auto& v : other)
+			this->operator[](v.first) *= v.second;
+		return *this;
+	}
 
 	//! divide 2 counters,
-    /**
-     * c1 /= c2
-     * =>
-     * c1 = {'a':1, 'b':1, 'c':0}
+	/**
+	 * c1 /= c2
+	 * =>
+	 * c1 = {'a':1, 'b':1, 'c':0}
 	 */
-    Counter& operator/=(const Counter& other) {
-        for (const auto& v : other)
-            this->operator[](v.first) /= v.second;
-        return *this;
-    }
+	Counter& operator/=(const Counter& other) {
+		for (const auto& v : other)
+			this->operator[](v.first) /= v.second;
+		return *this;
+	}
 
 	//! add CT to counter
 	/**
 	 * c1 += v
 	 * =>
-     * c1 = {'a':3, 'b':4}
+	 * c1 = {'a':3, 'b':4}
 	 */
-    Counter& operator+=(const CT& num) {
-        for (auto& v : *this)
-            v.second += num;
-        return *this;
-    }
+	Counter& operator+=(const CT& num) {
+		for (auto& v : *this)
+			v.second += num;
+		return *this;
+	}
 
 	/**
 	 * c1 -= v
 	 * =>
-     * c1 = {'a':-1, 'b':0}
+	 * c1 = {'a':-1, 'b':0}
 	 */
-    Counter& operator-=(const CT& num) {
-        for (auto& v : *this)
-            v.second -= num;
-        return *this;
-    }
+	Counter& operator-=(const CT& num) {
+		for (auto& v : *this)
+			v.second -= num;
+		return *this;
+	}
 
 	/**
 	 * c1 *= v
 	 * =>
-     * c1 = {'a':2, 'b':4}
+	 * c1 = {'a':2, 'b':4}
 	 */
-    Counter& operator*=(const CT& num) {
-        for (auto& v : *this)
-            v.second *= num;
-        return *this;
-    }
+	Counter& operator*=(const CT& num) {
+		for (auto& v : *this)
+			v.second *= num;
+		return *this;
+	}
 
 	/**
 	 * c1 /= v
 	 * =>
-     * c1 = {'a':0.5, 'b':1}
+	 * c1 = {'a':0.5, 'b':1}
 	 */
-    Counter& operator/=(const CT& num) {
-        for (auto& v : *this)
-            v.second /= num;
-        return *this;
-    }
+	Counter& operator/=(const CT& num) {
+		for (auto& v : *this)
+			v.second /= num;
+		return *this;
+	}
 };
 
 template<typename T, typename CT, typename CMP = std::less<T>>
 std::ostream& operator<<(std::ostream& out, const Counter<T, CT, CMP>& c)
 {
-    typedef Counter<T, CT, CMP> counter_t;
-    out << "{";
-    for (typename counter_t::const_iterator it = c.begin(); it != c.end();) {
-        out << it->first << ": " << it->second;
-        ++it;
-        if(it != c.end())
-            out << ", ";
-    }
-    out << "}";
-    return out;
+	typedef Counter<T, CT, CMP> counter_t;
+	out << "{";
+	for (typename counter_t::const_iterator it = c.begin(); it != c.end();) {
+		out << it->first << ": " << it->second;
+		++it;
+		if(it != c.end())
+			out << ", ";
+	}
+	out << "}";
+	return out;
 }
 
 /** @}*/

--- a/opencog/util/Counter.h
+++ b/opencog/util/Counter.h
@@ -60,8 +60,8 @@ protected:
 	template<typename IT>
 	void init(IT from, IT to) {
 		while(from != to) {
-			this->operator[](*from) += 1;  // we don't use ++ to put the
-										   // least assumption on on CT
+			//we don't use ++ to put the least assumption on on CT
+			this->operator[](*from) += 1;
 			++from;
 		}
 	}


### PR DESCRIPTION
@ngeiswei So I tried using the RetabIndent from the plugin you recommend but the result is the same. It converts 4 spaces into 1 tab which means as long as you display 1 tab as 4 spaces everything is still aligned correctly.
But since GitHub shows the first tab as 6 spaces long and all others as 8 spaces long this, of course, breaks the alignment. Which shows nicely why I prefer spaces.
Anyway, I fixed the misaligned end of line comment by moving it into its own line.