### PR TITLE
Fix build break, compiler warning, formatting. 

### DIFF
--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -276,21 +276,31 @@ template<typename FloatT> bool is_between(FloatT x, FloatT min_, FloatT max_)
     return x >= min_ && x <= max_;
 }
 
-// Compare floats with ULPS, because they are lexicographically
-// ordered. For technical explanation, see
-// http://www.cygnus-software.com/papers/comparingfloats/Comparing%20floating%20point%20numbers.htm
-bool is_approx_eq_ulp(double x,double y,long long int max_ulps)
+/// Compare floats with ULPS, because they are lexicographically
+/// ordered. For technical explanation, see
+/// http://www.cygnus-software.com/papers/comparingfloats/Comparing%20floating%20point%20numbers.htm
+/// and also it's new, improved variant:
+/// https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+///
+static inline bool is_approx_eq_ulp(double x, double y, long long int max_ulps)
 {
-	if ((x < 0) != (y < 0)) {
-		return x == y; //incase x==0 y==-0
+	if ((x < 0) != (y < 0))
+	{
+		return x == y; // in case x==0 and y==-0
 	}
-	long long int ulps = llabs(*(int64_t*) &(x) - *(int64_t*)&(y));
+
+	// Some compilers may need the __may_alias__ attribute ??
+	// int64_t* __attribute__((__may_alias__)) xbits = ...
+	int64_t* xbits = reinterpret_cast<int64_t*>(&x);
+	int64_t* ybits = reinterpret_cast<int64_t*>(&y);
+
+	long long int ulps = llabs(*xbits - *ybits);
 	return max_ulps > ulps;
 }
 
-bool is_approx_eq_ulp(double x,double y)
+static inline bool is_approx_eq_ulp(double x, double y)
 {
-	return is_approx_eq_ulp(x,y,MAX_ULPS);
+	return is_approx_eq_ulp(x, y, MAX_ULPS);
 }
 
 //! returns true iff abs(x - y) <= epsilon

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -282,19 +282,31 @@ template<typename FloatT> bool is_between(FloatT x, FloatT min_, FloatT max_)
 /// and also it's new, improved variant:
 /// https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
 ///
-static inline bool is_approx_eq_ulp(double x, double y, long long int max_ulps)
+static inline bool is_approx_eq_ulp(double x, double y, long int max_ulps)
 {
 	if ((x < 0) != (y < 0))
 	{
 		return x == y; // in case x==0 and y==-0
 	}
 
-	// Some compilers may need the __may_alias__ attribute ??
+	// Some compilers may need the __may_alias__ attribute to
+	// prevent a compiler warning.
+	//     warning: dereferencing type-punned pointer will break
+	//     strict-aliasing rules
 	// int64_t* __attribute__((__may_alias__)) xbits = ...
 	int64_t* xbits = reinterpret_cast<int64_t*>(&x);
 	int64_t* ybits = reinterpret_cast<int64_t*>(&y);
 
-	long long int ulps = llabs(*xbits - *ybits);
+	// The dereferencing is below is explicitly called out as
+	// "undefined behavior" by the C++ spec.  However, the spec
+	// also tells us how to do with correcly, when C++20 becomes
+	// available:
+	// labs(std::bit_cast<std::int64_t>(x) - std::bit_cast<std::int64_t>(y))
+
+	static_assert(sizeof(int64_t) == sizeof(double));
+	static_assert(sizeof(int64_t) == sizeof(long int));
+
+	long int ulps = labs(*xbits - *ybits);
 	return max_ulps > ulps;
 }
 


### PR DESCRIPTION
Multiple issues with the code. The build break was due to a missing `static inline` declaration.  The compiler warning was due to the C++ spec explicitly calling out this behavior as "undefined".  C++20 fixes this, but C++20 is not generally available, yet.