### PR TITLE
Major cleanup to numeric.h

### DIFF
--- a/opencog/util/Cover_Tree.h
+++ b/opencog/util/Cover_Tree.h
@@ -43,7 +43,7 @@
  *
  * The user should define double Point::distance(const Point& p) and
  * bool Point::operator==(const Point& p), where
- * p1.distance(p2)==0 doesn't necessarily mean that p1==p2). 
+ * p1.distance(p2)==0 doesn't necessarily mean that p1==p2).
  *
  * For example, a point could consist of a vector and a string
  * name, where their distance measure is simply euclidean distance but to be
@@ -119,12 +119,12 @@ class CoverTree
         void remove_point(const Point& p);
         const std::vector<Point>& get_points() { return _points; }
         double distance(const CoverTreeNode& p) const;
-        
+
         bool is_single() const;
         bool has_point(const Point& p) const;
-            
+
         const Point& get_point() const;
-        
+
         /**
          * Return every child of the node from any level. This is handy for
          * the destructor.
@@ -149,7 +149,7 @@ class CoverTree
     bool insert_rec(const Point& p,
                     const std::vector<distNodePair>& Qi,
                     const int& level);
-    
+
     /**
      * Finds the node in Q with the minimum distance to p. Returns a
      * pair consisting of this node and the distance.
@@ -157,7 +157,7 @@ class CoverTree
     distNodePair distance(const Point& p,
                           const std::vector<CoverTreeNode*>& Q);
 
-    
+
     void remove_rec(const Point& p,
                     std::map<int,std::vector<distNodePair> >& coverSets,
                     int level,
@@ -174,9 +174,9 @@ class CoverTree
      * p,q that you will ever try to insert. The cover tree may be invalid
      * if an inaccurate maxDist is given.
      */
-    
+
     CoverTree(const double& maxDist,
-              const std::vector<Point>& points=std::vector<Point>()); 
+              const std::vector<Point>& points=std::vector<Point>());
     ~CoverTree();
 
     /**
@@ -249,7 +249,7 @@ CoverTree<Point>::~CoverTree()
         //std::cout << _numNodes << "\n";
         delete byeNode;
         //_numNodes--;
-    }   
+    }
 }
 
 template<class Point>
@@ -467,7 +467,7 @@ CoverTree<Point>::distance(const Point& p,
             minNode = *it;
         }
     }
-    return std::make_pair(minDist,minNode);  
+    return std::make_pair(minDist,minNode);
 }
 
 template<class Point>
@@ -643,7 +643,7 @@ double CoverTree<Point>::CoverTreeNode::distance(const CoverTreeNode& p) const
 {
     return _points[0].distance(p.get_point());
 }
- 
+
 template<class Point>
 bool CoverTree<Point>::CoverTreeNode::is_single() const
 {
@@ -693,7 +693,7 @@ bool CoverTree<Point>::is_valid_tree() const {
             }
         }
         std::vector<CoverTreeNode*> allChildren;
-        for(it=nodes.begin(); it!=nodes.end(); ++it) {        
+        for(it=nodes.begin(); it!=nodes.end(); ++it) {
             std::vector<CoverTreeNode*> children = (*it)->get_children(i);
             //verify covering tree invariant: the children of node n at level
             //i are no further than base^i away
@@ -714,4 +714,4 @@ bool CoverTree<Point>::is_valid_tree() const {
 
 /** @}*/
 #endif // _COVER_TREE_H
- 
+

--- a/opencog/util/KLD.h
+++ b/opencog/util/KLD.h
@@ -1,4 +1,4 @@
-/** KLD.h --- 
+/** KLD.h ---
  *
  * Copyright (C) 2011 OpenCog Foundation
  *
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,
@@ -84,7 +84,7 @@ struct KLDS {
      * operator()
      */
     KLDS() : margin(1.0) {}
-    
+
     /**
      * @param p sorted sequence of values representing the distribution of P
      *
@@ -115,7 +115,7 @@ struct KLDS {
         return p_s;
     }
 
-    //! size of the pdf of p 
+    //! size of the pdf of p
     /**
      * (that is duplicate values are ignored).
      * This useful when one wants to know till when next can
@@ -124,7 +124,7 @@ struct KLDS {
     size_t p_pdf_size() const {
         return p_pdf.size();
     }
-    
+
     //! computes the components log(delta_p / delta_q) once at a time.
     /**
      * This is useful when one want to treat each component as a
@@ -151,7 +151,7 @@ struct KLDS {
         ++cit_p;
         return std::log(delta_p / delta_q);
     }
-    
+
     //! @return estimate of KL(P||Q)
     FloatT operator()(const pdf_t& q_counter) {
         FloatT q_s = boost::accumulate(q_counter | map_values, 0),
@@ -188,7 +188,7 @@ private:
             p_x_pre = p_x;
         }
     }
-    
+
     FloatT p_s,            // sizes of p used in
                            // the computation of LKD
         margin;
@@ -204,7 +204,7 @@ typename SortedSeq::value_type KLD(const SortedSeq& p, const SortedSeq& q) {
     KLDS<FloatT> klds(p);
     return klds(Counter<FloatT, FloatT>(q));
 }
-    
+
 ///@}
 /** @}*/
 } // ~namespace opencog

--- a/opencog/util/MannWhitneyU.h
+++ b/opencog/util/MannWhitneyU.h
@@ -1,4 +1,4 @@
-/* MannWhitneyU.h --- 
+/* MannWhitneyU.h ---
  *
  * Copyright (C) 2012 Nil Geisweiller
  *
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,

--- a/opencog/util/RandGen.h
+++ b/opencog/util/RandGen.h
@@ -37,7 +37,7 @@ namespace opencog
  */
 
 //! interface for random generators
-    
+
 // RandGen inherits std::mt19937. This may seem like a hack because
 // there is no point having that abstract class inherit a concrete
 // random generator. But it's clear we don't need that home made

--- a/opencog/util/algorithm.h
+++ b/opencog/util/algorithm.h
@@ -172,16 +172,16 @@ bool has_empty_intersection(const Set& ls, const Set& rs) {
  * Noob, taken from stackoverflow. WARNING: it doesn't check whether
  * the 2 containers are sorted.
  */
-template<class Set1, class Set2> 
+template<class Set1, class Set2>
 bool is_disjoint(const Set1 &set1, const Set2 &set2)
 {
     if (set1.empty() || set2.empty()) return true;
 
-    typename Set1::const_iterator 
-        from1 = set1.begin(), 
+    typename Set1::const_iterator
+        from1 = set1.begin(),
         to1 = set1.end();
-    typename Set2::const_iterator 
-        from2 = set2.begin(), 
+    typename Set2::const_iterator
+        from2 = set2.begin(),
         to2 = set2.end();
 
     if (*set2.rbegin() < *from1 || *set1.rbegin() < *from2) return true;
@@ -195,7 +195,7 @@ bool is_disjoint(const Set1 &set1, const Set2 &set2)
         else
             ++from2;
     }
-    
+
     return true;
 }
 

--- a/opencog/util/cluster.h
+++ b/opencog/util/cluster.h
@@ -6,7 +6,7 @@
  * Human Genome Center, Institute of Medical Science, University of Tokyo,
  * 4-6-1 Shirokanedai, Minato-ku, Tokyo 108-8639, Japan.
  * Contact: mdehoon 'AT' gsc.riken.jp
- * 
+ *
  * Permission to use, copy, modify, and distribute this software and its
  * documentation with or without modifications and for any purpose and
  * without fee is hereby granted, provided that any copyright notices
@@ -15,7 +15,7 @@
  * names of the contributors or copyright holders not be used in
  * advertising or publicity pertaining to distribution of the software
  * without specific prior permission.
- * 
+ *
  * THE CONTRIBUTORS AND COPYRIGHT HOLDERS OF THIS SOFTWARE DISCLAIM ALL
  * WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL THE
@@ -24,7 +24,7 @@
  * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
  * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE
  * OR PERFORMANCE OF THIS SOFTWARE.
- * 
+ *
  */
 
 #ifndef	_C_CLUSTERING_LIBRARY_H
@@ -238,7 +238,7 @@ returns 0. If successful, getclustercentroids returns 1.
 int getclustercentroids(int nclusters, int nrows, int ncolumns,
   double** data, int** mask, int clusterid[], double** cdata, int** cmask,
   int transpose, char method);
-  
+
 /**
 The getclustermedoids routine calculates the cluster centroids, given to which
 cluster each element belongs. The centroid is defined as the element with the
@@ -301,7 +301,7 @@ of the matrix are clustered.
 
 \param npass      (input) int
 The number of times clustering is performed. Clustering is performed npass
-times, each time starting from a different (random) initial assignment of 
+times, each time starting from a different (random) initial assignment of
 genes to clusters. The clustering solution with the lowest within-cluster sum
 of distances is chosen.
 If npass==0, then the clustering algorithm will be run once, where the initial

--- a/opencog/util/comprehension.h
+++ b/opencog/util/comprehension.h
@@ -1,4 +1,4 @@
-/* comprehension.h --- 
+/* comprehension.h ---
  *
  * Copyright (C) 2012 Nil Geisweiller
  *
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,
@@ -65,7 +65,7 @@ namespace opencog {
 typedef const_function<bool> const_bool;
 static const const_bool default_filter(true);
 
-    
+
 //! vector comprehension (STL functor version)
 template<typename Container, typename Function, typename Filter=const_bool>
 auto vector_comp(const Container& c, const Function& func,
@@ -128,7 +128,7 @@ auto list_comp(const Container& c, const Function& func,
 //                                                                                                                        //
 // Anyway it's weird enough that I'd rather not even try to attempt fix that for now, I think it might well be a gcc bug. //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    
+
 /// @todo set comprehension (STL functor version)
 // template<typename Container, typename Function, typename Filter = const_bool>
 // auto set_comp(const Container& c, const Function& func,

--- a/opencog/util/digraph.h
+++ b/opencog/util/digraph.h
@@ -70,7 +70,7 @@ struct digraph {
     //! return the set of all direct predecessor nodes of x
     const value_set& incoming(value_type x) const {
         return _incoming[x];
-    }    
+    }
     //! return the set of all direct successor nodes of x
     const value_set& outgoing(value_type x) const {
         return _outgoing[x];

--- a/opencog/util/files.h
+++ b/opencog/util/files.h
@@ -93,14 +93,14 @@ bool append_file_content(const char* filename, std::string &s);
 bool load_text_file(const std::string &fname, std::string& dest);
 
 /**
- * Get the file name (including absolute path) of current executing file 
+ * Get the file name (including absolute path) of current executing file
  */
 std::string get_exe_name();
 
 /**
  * Get the absolute path (including "/" at the end) where the current executing file runs
  */
-std::string get_exe_dir(); 
+std::string get_exe_dir();
 
 /** @}*/
 } // namespace opencog

--- a/opencog/util/hashing.h
+++ b/opencog/util/hashing.h
@@ -70,7 +70,7 @@ std::size_t hash_value(const tree<T>& tr)
     return boost::hash_range(tr.begin(), tr.end());
 }
 
-//! Functor comparing the addresses of objects pointed by 
+//! Functor comparing the addresses of objects pointed by
 //! tree iterators.
 /**
  * Useful for storing iterators in a std::map.

--- a/opencog/util/iostreamContainer.h
+++ b/opencog/util/iostreamContainer.h
@@ -1,4 +1,4 @@
-/* iostreamContainer.h --- 
+/* iostreamContainer.h ---
  *
  * Copyright (C) 2010 OpenCog Foundation
  *
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,
@@ -42,8 +42,8 @@ namespace opencog {
      * functions to read, write, print or convert to string generic containers
      */
     ///@{
-    
-    
+
+
     /**
      * stream out all elements in [from, to( with delimiter
      * 'delimiter', opening with 'left' and closing with 'right'.
@@ -87,7 +87,7 @@ namespace opencog {
     Out& ostream_container(Out& out,
                            const Con& container,
                            const std::string& delimiter = " ",
-                           const std::string& left = "", 
+                           const std::string& left = "",
                            const std::string& right = "",
                            bool empty_lr = true)
     {
@@ -95,7 +95,7 @@ namespace opencog {
                                  delimiter, left, right, empty_lr);
     }
 
-    
+
     /**
      * like ostream_container but adding a new line at the end
      */
@@ -120,7 +120,7 @@ namespace opencog {
     Out& ostreamln_container(Out& out,
                              const Con& container,
                              const std::string& delimiter = " ",
-                             const std::string& left = "", 
+                             const std::string& left = "",
                              const std::string& right = "",
                              bool empty_lr = true)
     {
@@ -147,7 +147,7 @@ namespace opencog {
     template<class Con>
     void print_container(const Con& container,
                          const std::string& delimiter = " ",
-                         const std::string& left = "", 
+                         const std::string& left = "",
                          const std::string& right = "",
                          bool empty_lr = true)
     {
@@ -172,7 +172,7 @@ namespace opencog {
     template<class Con>
     void println_container(const Con& container,
                            const std::string& delimiter = " ",
-                           const std::string& left = "", 
+                           const std::string& left = "",
                            const std::string& right = "",
                            bool empty_lr = true)
     {
@@ -198,7 +198,7 @@ namespace opencog {
     template<class Con>
     std::string container_to_str(const Con& container,
                                  const std::string& delimiter = " ",
-                                 const std::string& left = "", 
+                                 const std::string& left = "",
                                  const std::string& right = "",
                                  bool empty_lr = true)
     {
@@ -230,7 +230,7 @@ namespace opencog {
 
     /**
      * stream all elements in 'in' and put them in the container.
-     * For instance 
+     * For instance
      * std::stringstream ss("[1 2 3 4] 5");
      * std::vector<int> nums;
      * istreamContainer(ss, back_inserter(nums), "[", "]");
@@ -289,7 +289,7 @@ namespace opencog {
         }
         return in;
     }
-    
+
     ///@}
 
 /** @}*/

--- a/opencog/util/jaccard_index.h
+++ b/opencog/util/jaccard_index.h
@@ -1,4 +1,4 @@
-/** jaccard_index.h --- 
+/** jaccard_index.h ---
  *
  * Copyright (C) 2014 OpenCog Foundation
  *

--- a/opencog/util/lazy_selector.cc
+++ b/opencog/util/lazy_selector.cc
@@ -72,7 +72,7 @@ void lazy_selector::reset_range(unsigned int new_u, unsigned int new_l) {
  *
  * It works by creating a mapping between already selected indices and
  * free indices (never selected yet).
- * 
+ *
  * To chose the free indices, we use an index _l, that
  * goes from the lower range to the upper range and only corresponds to
  * free indices. So every time _l corresponds to a non free index
@@ -84,7 +84,7 @@ unsigned int lazy_selector::operator()()
     OC_ASSERT(!empty(), "lazy_selector - selector is empty.");
 
     unsigned int sel_idx = select();
-    
+
     // If the selected index points to nothing then the result is
     // itself otherwise it is _l
     unsigned int res = is_free(sel_idx) ? sel_idx : _l;

--- a/opencog/util/lazy_selector.h
+++ b/opencog/util/lazy_selector.h
@@ -74,7 +74,7 @@ private:
 
     //! an index is free if it has never been chosen before
     //! that is if no links are going out of it
-    inline bool is_free(unsigned int idx) const; 
+    inline bool is_free(unsigned int idx) const;
 
     //! increase _l until it is located on a free index
     inline void increase_l_till_free();

--- a/opencog/util/log_prog_name.cc
+++ b/opencog/util/log_prog_name.cc
@@ -1,4 +1,4 @@
-/** log_prog_name.cc --- 
+/** log_prog_name.cc ---
  *
  * Copyright (C) 2011 OpenCog Foundation
  *
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,

--- a/opencog/util/log_prog_name.h
+++ b/opencog/util/log_prog_name.h
@@ -1,4 +1,4 @@
-/* log_prog_name.h --- 
+/* log_prog_name.h ---
  *
  * Copyright (C) 2011 OpenCog Foundation
  *
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,

--- a/opencog/util/macros.h
+++ b/opencog/util/macros.h
@@ -39,7 +39,7 @@
 #define TRACE_INFO " (" __FILE__ ":" TOSTRING(__LINE__) ")"
 //! supress compiler warnings about unused variables
 #define OC_UNUSED(varname)	(void)varname;
-//! check the return value of a fread; sets b_read local variable 
+//! check the return value of a fread; sets b_read local variable
 //! to false for failure; b_read must have beed declared before:
 //! bool b_read = true;
 #define FREAD_CK(ptr,size,count,stream) \

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -53,12 +53,12 @@
 namespace opencog
 {
 
-// XXX FIXME; these should almost surely be replaced by
-// some version of std::numeric_limits<double>::epsilon
-const double EPSILON = 1e-6; // default error when comparing 2 floats
-const double SMALL_EPSILON = 1e-32;
-const double PROB_EPSILON = 1e-127; // error when comparing 2 probabilities
-const int MAX_ULPS = 24;
+// Maximum acceptable difference when comparing probabilities.
+#define PROB_EPSILON 1e-127
+// Maximum acceptable difference when comparing distances.
+#define DISTANCE_EPSILON 1e-32
+
+#define MAX_ULPS 24
 
 //! absolute_value_order
 //!   codes the following order, for T == int, -1,1,-2,2,-3,3,...
@@ -216,7 +216,7 @@ template<typename FloatT> bool is_approx_eq(FloatT x, FloatT y, FloatT epsilon)
 /// note that, unlike isWithin, the precision adapts with the scale of x and y
 template<typename FloatT> bool is_approx_eq(FloatT x, FloatT y)
 {
-    return is_approx_eq(x, y, static_cast<FloatT>(EPSILON));
+    return is_approx_eq(x, y, std::numeric_limits<FloatT>::epsilon());
 }
 
 // TODO: replace the following by C++17 std::clamp
@@ -400,7 +400,7 @@ Float tanimoto_distance(const Vec& a, const Vec& b)
         bb = boost::inner_product(b, b, Float(0)),
         numerator = aa + bb - ab;
 
-    if (numerator >= Float(SMALL_EPSILON))
+    if (numerator >= Float(DISTANCE_EPSILON))
         return 1 - (ab / numerator);
     else
         return 0;
@@ -441,7 +441,7 @@ Float angular_distance(const Vec& a, const Vec& b, bool pos_n_neg = true)
         bb = boost::inner_product(b, b, Float(0)),
         numerator = sqrt(aa * bb);
     
-    if (numerator >= Float(SMALL_EPSILON)) {
+    if (numerator >= Float(DISTANCE_EPSILON)) {
         // in case of rounding error
         Float r = clamp(ab / numerator, Float(-1), Float(1));
         return (pos_n_neg ? 1 : 2) * acos(r) / PI;
@@ -449,6 +449,11 @@ Float angular_distance(const Vec& a, const Vec& b, bool pos_n_neg = true)
     else
         return 0;
 }
+
+// Avoid spewing garbage into the namespace!
+#undef PROB_EPSILON
+#undef DISTANCE_EPSILON
+#undef MAX_ULPS
 
 } // ~namespace opencog
 /** @}*/

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -149,6 +149,7 @@ inline unsigned int integer_log2(size_t v)
 inline unsigned int nbits_to_pack(size_t multy)
 {
     OC_ASSERT(multy > 0);
+// #define ALIGNED_NOT_ACTUALLY_REQUIRED 1
 #ifdef ALIGNED_NOT_ACTUALLY_REQUIRED
     return integer_log2(multy -1) + 1;
 #else

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -137,7 +137,7 @@ inline unsigned int nbits_to_pack(size_t multy)
 //! returns true iff x >= min and x <= max
 template<typename FloatT> bool is_between(FloatT x, FloatT min_, FloatT max_)
 {
-    return x >= min_ && x <= max_;
+    return x >= min_ and x <= max_;
 }
 
 /// Compare floats with ULPS, because they are lexicographically
@@ -217,7 +217,7 @@ template<typename FloatT> FloatT weighted_information(FloatT p)
 //! compute the binary entropy of probability p
 template<typename FloatT> FloatT binary_entropy(FloatT p)
 {
-    OC_ASSERT(p >= 0 && p <= 1,
+    OC_ASSERT(p >= 0 and p <= 1,
               "binaryEntropy: probability %f is not between 0 and 1", p);
     return weighted_information(p) + weighted_information(1.0 - p);
 }
@@ -257,7 +257,7 @@ template<typename IntT> IntT smallest_divisor(IntT n)
     else {
         bool found_divisor = false;
         IntT i = 2;
-        for(; i*i <= n && !found_divisor; i++) {
+        for(; i*i <= n and !found_divisor; i++) {
             found_divisor = n%i==0;
         }
         if(found_divisor)

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -199,10 +199,10 @@ template<typename FloatT> bool is_within(FloatT x, FloatT y, FloatT epsilon)
 template<typename FloatT> bool is_approx_eq(FloatT x, FloatT y, FloatT epsilon)
 {
     FloatT diff = std::fabs(x - y);
+    if (diff < epsilon) return true;
+
     FloatT amp = std::fabs(x + y);
-    if (amp*amp > epsilon)
-        return diff <= epsilon * amp;
-    else return diff <= epsilon;
+    return diff <= epsilon * amp;
 }
 
 //! compare 2 FloatT with precision EPSILON

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -53,20 +53,6 @@
 namespace opencog
 {
 
-using std::numeric_limits;
-using std::isnan;
-using std::isfinite;
-using std::isinf;
-
-using std::iota;
-
-#ifndef WIN32
-// This needs to be changed for non-gcc. Note however that so far it
-// has been useless as most of the time you just need pow2 or sq
-// defined below in that header
-using __gnu_cxx::power;
-#endif
-
 // XXX FIXME; these should almost surely be replaced by
 // some version of std::numeric_limits<double>::epsilon
 const double EPSILON = 1e-6; // default error when comparing 2 floats
@@ -306,7 +292,7 @@ template<typename T> T sq(T x) { return x*x; }
 //! check if x isn't too high and return 2^x
 template<typename OutInt> OutInt pow2(unsigned int x)
 {
-    OC_ASSERT(8*sizeof(OutInt) - (numeric_limits<OutInt>::is_signed?1:0) > x,
+    OC_ASSERT(8*sizeof(OutInt) - (std::numeric_limits<OutInt>::is_signed?1:0) > x,
               "pow2: Amount to shift is out of range.");
     return static_cast<OutInt>(1) << x;
 }
@@ -444,6 +430,11 @@ Float angular_distance(const Vec& a, const Vec& b, bool pos_n_neg = true)
                "Cannot compare unequal-sized vectors!  %d %d\n",
                a.size(), b.size());
 
+    // XXX FIXME writing out the explicit loop will almost
+    // surely be faster than calling boost. Why? Because a single
+    // loop allows the compiler to insert instructions into the
+    // pipeline bubbles; whereas three different loops will be more
+    // than three times slower!
     Float ab = boost::inner_product(a, b, Float(0)),
         aa = boost::inner_product(a, a, Float(0)),
         bb = boost::inner_product(b, b, Float(0)),

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -67,6 +67,8 @@ using std::iota;
 using __gnu_cxx::power;
 #endif
 
+// XXX FIXME; these should almost surely be replaced by
+// some version of std::numeric_limits<double>::epsilon
 const double EPSILON = 1e-6; // default error when comparing 2 floats
 const double SMALL_EPSILON = 1e-32;
 const double PROB_EPSILON = 1e-127; // error when comparing 2 probabilities
@@ -85,24 +87,6 @@ struct absolute_value_order
 /** @name Bithacks
  */
 ///@{
-
-//! return p the smallest power of 2 so that p >= x
-/// So for instance:
-///   - next_power_of_two(1) = 1
-///   - next_power_of_two(2) = 2
-///   - next_power_of_two(3) = 4
-inline size_t next_power_of_two(size_t x)
-{
-    OC_ASSERT(x > 0);
-    x--;
-    x |= x >> 1;
-    x |= x >> 2;
-    x |= x >> 4;
-    x |= x >> 8;
-    x |= x >> 16;
-    x++;
-    return x;
-}
 
 /// Return the index of the first non-zero bit in the integer value,
 /// minus one.
@@ -128,6 +112,28 @@ inline unsigned int integer_log2(size_t v)
     v |= v >> 16;
     v = (v >> 1) + 1;
     return MultiplyDeBruijnBitPosition[static_cast<uint32_t>(v * 0x077CB531UL) >> 27];
+#endif
+}
+
+//! return p the smallest power of 2 so that p >= x
+/// So for instance:
+///   - next_power_of_two(1) = 1
+///   - next_power_of_two(2) = 2
+///   - next_power_of_two(3) = 4
+inline size_t next_power_of_two(size_t x)
+{
+    OC_ASSERT(x > 0);
+#ifdef __GNUC__
+    return 1UL << (8*sizeof(size_t) - __builtin_clzl(x-1));
+#else
+    x--;
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+    x++;
+    return x;
 #endif
 }
 

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -110,6 +110,7 @@ inline size_t next_power_of_two(size_t x)
 {
     OC_ASSERT(x > 0);
 #ifdef __GNUC__
+    if (1==x) return 1;  // because __builtin_clzl(0) is -MAX_INT
     return 1UL << (8*sizeof(size_t) - __builtin_clzl(x-1));
 #else
     x--;

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -133,13 +133,6 @@ inline unsigned int nbits_to_pack(size_t multy)
     return next_power_of_two(integer_log2(multy -1) + 1);
 }
 
-//! return the number of digits (in base 10 by default) of an integer
-template<typename Int> Int ndigits(Int x, Int base = 10) {
-    Int nd = 0;
-    while (x != 0) { x /= base; nd++; }
-    return nd;
-}
-
 //! returns true iff x >= min and x <= max
 template<typename FloatT> bool is_between(FloatT x, FloatT min_, FloatT max_)
 {

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -40,21 +40,12 @@
  *  @{
  */
 
-// These and many other constants are in <math.h>
-#define PI          M_PI  // 3.1415926535897932384626433832795029L
-#define EXPONENTIAL M_E   // 2.7182818284590452353602874713526625L
-
-#ifdef WIN32
-#include <numeric>
-#else
-#include <ext/numeric>
-#endif
-
 namespace opencog
 {
 
 // Maximum acceptable difference when comparing probabilities.
 #define PROB_EPSILON 1e-127
+
 // Maximum acceptable difference when comparing distances.
 #define DISTANCE_EPSILON 1e-32
 
@@ -68,19 +59,14 @@ struct absolute_value_order
     }
 };
 
-/** @name Bithacks
- */
-///@{
-
 /// Return the index of the first non-zero bit in the integer value,
 /// minus one.
 inline unsigned int integer_log2(size_t v)
 {
 #ifdef __GNUC__
-    // On x86_64, this uses the BSR (Bit scane Reverse) insn or
+    // On x86_64, this uses the BSR (Bit Scan Reverse) insn or
     // the LZCNT (Leading Zero Count) insn.
-    // This should also work on ARM, according to the interwebs.
-    // And other arches, including POWER (?!)
+    // This should work on all arches; its part of GIL/gimple.
     if (0 == v) return 0;
     return (8*sizeof(size_t) - 1) - __builtin_clzl(v);
 #else
@@ -307,9 +293,6 @@ Float generalized_mean(const C& c, Float p = 1.0)
     return generalized_mean(c.begin(), c.end(), p);
 }
 
-///@}
-
-
 /// Compute the distance between two vectors, using the p-norm.  For
 /// p=2, this is the usual Eucliden distance, and for p=1, this is the
 /// Manhattan distance, and for p=0 or negative, this is the maximum
@@ -437,7 +420,7 @@ Float angular_distance(const Vec& a, const Vec& b, bool pos_n_neg = true)
     if (numerator >= Float(DISTANCE_EPSILON)) {
         // in case of rounding error
         Float r = clamp(ab / numerator, Float(-1), Float(1));
-        return (pos_n_neg ? 1 : 2) * acos(r) / PI;
+        return (pos_n_neg ? 1 : 2) * acos(r) / M_PI;
     }
     else
         return 0;

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -58,8 +58,6 @@ namespace opencog
 // Maximum acceptable difference when comparing distances.
 #define DISTANCE_EPSILON 1e-32
 
-#define MAX_ULPS 24
-
 //! absolute_value_order
 //!   codes the following order, for T == int, -1,1,-2,2,-3,3,...
 template<typename T>
@@ -188,11 +186,6 @@ static inline bool is_approx_eq_ulp(double x, double y, long int max_ulps)
 
 	long int ulps = labs(*xbits - *ybits);
 	return max_ulps > ulps;
-}
-
-static inline bool is_approx_eq_ulp(double x, double y)
-{
-	return is_approx_eq_ulp(x, y, MAX_ULPS);
 }
 
 //! returns true iff abs(x - y) <= epsilon
@@ -453,7 +446,6 @@ Float angular_distance(const Vec& a, const Vec& b, bool pos_n_neg = true)
 // Avoid spewing garbage into the namespace!
 #undef PROB_EPSILON
 #undef DISTANCE_EPSILON
-#undef MAX_ULPS
 
 } // ~namespace opencog
 /** @}*/

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -167,8 +167,8 @@ static inline bool is_approx_eq_ulp(double x, double y, long int max_ulps)
 	// available:
 	// labs(std::bit_cast<std::int64_t>(x) - std::bit_cast<std::int64_t>(y))
 
-	static_assert(sizeof(int64_t) == sizeof(double));
-	static_assert(sizeof(int64_t) == sizeof(long int));
+	static_assert(sizeof(int64_t) == sizeof(double), "Unexpected sizeof(double)");
+	static_assert(sizeof(int64_t) == sizeof(long int), "Unexpected sizeof(long int)");
 
 	long int ulps = labs(*xbits - *ybits);
 	return max_ulps > ulps;

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -228,8 +228,8 @@ template<typename FloatT> FloatT binary_entropy(FloatT p)
  * Specifically it computes
  *
  * - Sum_i p_i log_2(p_i)
- * 
- * where the p_i are values pointed by (from, to[, 
+ *
+ * where the p_i are values pointed by (from, to[,
  * It is assumed that Sum_i p_i == 1.0
  * That is, std::accumulate(from, to, 0) == 1.0
  */
@@ -416,7 +416,7 @@ Float angular_distance(const Vec& a, const Vec& b, bool pos_n_neg = true)
         aa = boost::inner_product(a, a, Float(0)),
         bb = boost::inner_product(b, b, Float(0)),
         numerator = sqrt(aa * bb);
-    
+
     if (numerator >= Float(DISTANCE_EPSILON)) {
         // in case of rounding error
         Float r = clamp(ab / numerator, Float(-1), Float(1));

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -83,37 +83,8 @@ struct absolute_value_order
 };
 
 /** @name Bithacks
- *
- * The following functions are adapted from the bit twiddling hacks page:
- * http://graphics.stanford.edu/~seander/bithacks.html
- * 32-bit version is faster, than the others
- * but beware, you need to check the number of bits yourself
- * awkward phrasing cuz c++ doesn't allow partial specialization of functions
- *
- * a few possibilities were tried; gcc has a built-in function called
- * __builtin_popcount which is somewhat slower. Using a lookup table might
- * be somwhat faster under some circumstances, but was avoided because it
- * might hog the fast memory ...
  */
 ///@{
-
-//! count_bits will work up to 128-bits
-template<typename T>
-inline unsigned int count_bits32(T v)
-{
-    v = v - ((v >> 1) & 0x55555555);                    // reuse input as temp
-    v = (v & 0x33333333) + ((v >> 2) & 0x33333333);     // temp
-    return ((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24; // count
-}
-
-template<typename T>
-inline unsigned int count_bits(T v)
-{
-    v = v - ((v >> 1) & (T)~(T)0 / 3);                         // temp
-    v = (v & (T)~(T)0 / 15 * 3) + ((v >> 2) & (T)~(T)0 / 15 * 3);      // temp
-    v = (v + (v >> 4)) & (T)~(T)0 / 255 * 15;                  // temp
-    return ((T)(v * ((T)~(T)0 / 255)) >> (sizeof(v) - 1) * CHAR_BIT);
-}
 
 //! return p the smallest power of 2 so that p >= x
 /// So for instance:

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -33,10 +33,8 @@
 
 #include <boost/range/numeric.hpp>
 
-#include <opencog/util/exceptions.h>
-#include <opencog/util/oc_assert.h>
-
 #include <opencog/util/iostreamContainer.h>
+#include <opencog/util/oc_assert.h>
 
 /** \addtogroup grp_cogutil
  *  @{
@@ -180,6 +178,7 @@ inline unsigned int count_bits32(T v)
     v = (v & 0x33333333) + ((v >> 2) & 0x33333333);     // temp
     return ((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24; // count
 }
+
 template<typename T>
 inline unsigned int count_bits(T v)
 {
@@ -239,28 +238,6 @@ inline unsigned int nbits_to_pack(size_t multy)
 {
     OC_ASSERT(multy > 0);
     return next_power_of_two(integer_log2(multy -1) + 1);
-}
-
-//! sums of natural logarithms (for a particular floating-point type)
-template<typename FloatT>
-FloatT logsum(size_t n)
-{
-    static std::vector<FloatT> sums;
-    if (n >= sums.size()) {
-        int to = next_power_of_two(n) + 2;
-        sums.reserve(to);
-        if (sums.empty()) {
-            sums.push_back(0);
-            sums.push_back(0);
-        }
-
-        FloatT v = sums.back();
-        for (int i = sums.size();i < to;++i) {
-            v += log(FloatT(i - 1));
-            sums.push_back(v);
-        }
-    }
-    return sums[n];
 }
 
 //! return the number of digits (in base 10 by default) of an integer

--- a/opencog/util/oc_omp.cc
+++ b/opencog/util/oc_omp.cc
@@ -1,4 +1,4 @@
-/** oc_omp.cc --- 
+/** oc_omp.cc ---
  *
  * Copyright (C) 2011 Nil Geisweiller
  *
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,

--- a/opencog/util/oc_omp.h
+++ b/opencog/util/oc_omp.h
@@ -1,4 +1,4 @@
-/* oc_omp.h --- 
+/* oc_omp.h ---
  *
  * Copyright (C) 2011 Nil Geisweiller
  *
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,
@@ -34,11 +34,11 @@
  * of the STL algorithms.  To use them, include this file and put the
  * namespace OMP_ALGO in front of the algorithm.  For example,
  * OMP_ALGO::for_each(...) provides the parallel version of
- * std::for_each().  
+ * std::for_each().
  *
  * If the cpp define OC_OMP is defined, the parallel versions of the
  * std algorithms are used.   Disabling this define allows code to be
- * compiled with compilers that do not (yet) implement OMP, such as 
+ * compiled with compilers that do not (yet) implement OMP, such as
  * LLVM clang.
  */
 ///@{
@@ -67,7 +67,7 @@ void setting_omp(unsigned num_threads, unsigned min_n = 50);
 unsigned num_threads();
 
 //! split the number of jobs in 2. For instance if n_jobs is 3, then it
-//! returns <1, 2>. 
+//! returns <1, 2>.
 /// This function is convenient for parallalizing
 /// recursive functions
 std::pair<unsigned, unsigned> split_jobs(unsigned n_jobs);

--- a/opencog/util/platform.cc
+++ b/opencog/util/platform.cc
@@ -28,7 +28,7 @@
 
 namespace opencog {
 
-const char* getUserName() { 
+const char* getUserName() {
     const char* username = getenv("LOGNAME");
     if (username == NULL)
         username = getenv("USER");
@@ -177,7 +177,7 @@ size_t opencog::getMemUsage()
 {
     static void *old_sbrk = 0;
     void *p = sbrk(0);
-    if (old_sbrk == 0 || old_sbrk > p) 
+    if (old_sbrk == 0 || old_sbrk > p)
     {
         old_sbrk = p;
         return 0;
@@ -201,10 +201,10 @@ uint64_t opencog::getTotalRAM()
    len = sizeof(physmem);
    sysctl(mib, 2, &physmem, &len, NULL, 0);
    return physmem;
-    
 }
 
-uint64_t opencog::getFreeRAM() {
+uint64_t opencog::getFreeRAM()
+{
     return getTotalRAM() - getMemUsage();
 }
 

--- a/opencog/util/random.h
+++ b/opencog/util/random.h
@@ -102,8 +102,8 @@ template<typename T>
 T gaussian_rand(T mean, T std_dev, RandGen& rng=randGen())
 {
     double val = mean + std_dev *
-        std::sqrt(-2 * std::log(rng.randdouble_one_excluded())) * 
-        std::cos(2 * PI * rng.randdouble_one_excluded());
+        std::sqrt(-2.0 * std::log(rng.randdouble_one_excluded())) *
+        std::cos(2.0 * M_PI * rng.randdouble_one_excluded());
     T res;
     try {
         res = boost::numeric_cast<T>(val);

--- a/opencog/util/random.h
+++ b/opencog/util/random.h
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,

--- a/opencog/util/ranking.h
+++ b/opencog/util/ranking.h
@@ -1,4 +1,4 @@
-/* ranking.h --- 
+/* ranking.h ---
  *
  * Copyright (C) 2012 Nil Geisweiller
  *
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,
@@ -33,7 +33,7 @@ namespace opencog {
 
 //! Return a rank given a counter. Ties ranks are averaged.
 /**
- * Given a Counter {'blue': 3, 'red': 2, 'green': 1}, it will produce a 
+ * Given a Counter {'blue': 3, 'red': 2, 'green': 1}, it will produce a
  * new Counter {'blue': 3, 'red': 4.5, 'green': 6}
  */
 template<typename Key, typename FloatT>

--- a/opencog/util/sigslot.h
+++ b/opencog/util/sigslot.h
@@ -51,7 +51,7 @@ class SigSlot
 		mutable std::mutex _mtx;
 		// HACK ALERT -- use std::map, not std::set here, for only
 		// one reason: so that we get a natural operator-less, which
-		// is needed for the insert() to work. 
+		// is needed for the insert() to work.
 
 		mutable std::map<int, std::function<void(ARGS...)>> _slots;
 		mutable int _slot_id;

--- a/opencog/util/tbb.h
+++ b/opencog/util/tbb.h
@@ -3,15 +3,15 @@
 
 /*
  * Helper function for tbb::task::enqueue
- * 
+ *
  * Enqueue a task for execution by the TBB task scheduler using lambda expressions
- * 
+ *
  * Usage:
- * 
- *   tbb_enqueue_lambda( []{ 
+ *
+ *   tbb_enqueue_lambda( []{
  *       // put code here
  *   } );
- * 
+ *
  * More information:
  *   http://www.threadingbuildingblocks.org/docs/help/index.htm#reference/task_scheduler/task_cls.htm
  */

--- a/opencog/util/tree.cc
+++ b/opencog/util/tree.cc
@@ -11,7 +11,7 @@ tree<string>::iterator at = tr.begin();
 
 void begin_internal(const char* from, const char* to)
 {
-    at = tr.empty() 
+    at = tr.empty()
         ? tr.insert(at,string(from, to-1))
         : tr.append_child(at,string(from, to-1));
 }
@@ -38,11 +38,11 @@ struct TreeGrammar : public grammar<TreeGrammar>
     {
         definition(const TreeGrammar&)
         {
-            term = 
+            term =
                 lexeme_d[// or a message M with the syntax message:"M"
                          // added this to parse correctly has_said perceptions
                          // XXX THIS IS A HACK -- FIXME
-                         ( str_p("message:") >> ch_p('"') 
+                         ( str_p("message:") >> ch_p('"')
                            >> *(anychar_p - ch_p('"')) >> ch_p('"'))
                          | (+( anychar_p - ch_p('(') - ch_p(')') - space_p))]
                 [&add_leaf];
@@ -54,7 +54,7 @@ struct TreeGrammar : public grammar<TreeGrammar>
             //expr=term | (term >> '(' >> +expr >> ')');
         }
         rule<ScannerT> expr, beg, term;
-  
+
         const rule<ScannerT>& start() const { return expr; }
     };
 };
@@ -85,7 +85,7 @@ std::istream& operator>>(std::istream& in,opencog::tree<std::string>& t)
         // replaced by "yo man" (where a space is missing)
         // This assumes that there are no '(' and ')' in the quoted string.
         std::getline(in, tmp);
-        nparen += count(tmp.begin(), tmp.end(), '(') 
+        nparen += count(tmp.begin(), tmp.end(), '(')
                  - count(tmp.begin(), tmp.end(), ')');
         str += tmp + ' ';
     } while (in.good() && nparen>0);
@@ -127,7 +127,7 @@ std::istream& operator>>(std::istream& in,opencog::tree<std::string>& t)
        i++; j++;
     }
     str[j] = 0x0; // null terminate
-    
+
     t = parse_string_tree(str);
     return in;
 }

--- a/opencog/util/tree.h
+++ b/opencog/util/tree.h
@@ -3257,7 +3257,7 @@ unsigned int pre_order_index(const tree<T>& tr,
         ++i;
     }
     return i;
-}                                
+}
 
 template<typename iter>
 std::string subtree_to_string(iter it)

--- a/tests/util/numericUTest.cxxtest
+++ b/tests/util/numericUTest.cxxtest
@@ -86,13 +86,14 @@ public:
             res_4 = next_power_of_two(4),
             res_5 = next_power_of_two(5),
             res_50 = next_power_of_two(50),
+            res_255 = next_power_of_two(255),
             res_256 = next_power_of_two(256),
             res_257 = next_power_of_two(257);
 
         cout << "test_next_power_of_two: ";
         cout << res_1 << " " << res_2 << " " << res_3 << " "
              << res_4 << " " << res_5 << " "
-             << res_50 << " "
+             << res_50 << " " << res_255 << " "
              << res_256 << " " << res_257 << endl;
 
         TS_ASSERT_EQUALS(res_1, 1);
@@ -101,6 +102,7 @@ public:
         TS_ASSERT_EQUALS(res_4, 4);
         TS_ASSERT_EQUALS(res_5, 8);
         TS_ASSERT_EQUALS(res_50, 64);
+        TS_ASSERT_EQUALS(res_255, 256);
         TS_ASSERT_EQUALS(res_256, 256);
         TS_ASSERT_EQUALS(res_257, 512);
     }

--- a/tests/util/numericUTest.cxxtest
+++ b/tests/util/numericUTest.cxxtest
@@ -84,17 +84,25 @@ public:
             res_2 = next_power_of_two(2),
             res_3 = next_power_of_two(3),
             res_4 = next_power_of_two(4),
-            res_5 = next_power_of_two(5);
+            res_5 = next_power_of_two(5),
+            res_50 = next_power_of_two(50),
+            res_256 = next_power_of_two(256),
+            res_257 = next_power_of_two(257);
 
         cout << "test_next_power_of_two: ";
         cout << res_1 << " " << res_2 << " " << res_3 << " "
-             << res_4 << " " << res_5 << endl;
+             << res_4 << " " << res_5 << " "
+             << res_50 << " "
+             << res_256 << " " << res_257 << endl;
 
         TS_ASSERT_EQUALS(res_1, 1);
         TS_ASSERT_EQUALS(res_2, 2);
         TS_ASSERT_EQUALS(res_3, 4);
         TS_ASSERT_EQUALS(res_4, 4);
         TS_ASSERT_EQUALS(res_5, 8);
+        TS_ASSERT_EQUALS(res_50, 64);
+        TS_ASSERT_EQUALS(res_256, 256);
+        TS_ASSERT_EQUALS(res_257, 512);
     }
 
     void test_nbits_to_pack()

--- a/tests/util/numericUTest.cxxtest
+++ b/tests/util/numericUTest.cxxtest
@@ -44,13 +44,16 @@ public:
                                  << "d3: " << d3 << endl
                                  << "d4: " << d4 << endl;
         TS_ASSERT(not (d3 == d4))
-        TS_ASSERT(is_approx_eq_ulp(d3,d4))
+
+// Allow as many as 24 bits to be different.
+#define COMPARE_ULPS 24
+        TS_ASSERT(is_approx_eq_ulp(d3, d4, COMPARE_ULPS))
 
         double d5 = -0.0000000000000000000000000000001,
                d6 =  0.0000000000000000000000000000001;
 
-        TS_ASSERT(not is_approx_eq_ulp(d5,d6))
-        TS_ASSERT(not is_approx_eq_ulp(d5,0.0))
+        TS_ASSERT(not is_approx_eq_ulp(d5, d6, COMPARE_ULPS))
+        TS_ASSERT(not is_approx_eq_ulp(d5, 0.0, COMPARE_ULPS))
     }
 
     void test_integer_log2()

--- a/tests/util/numericUTest.cxxtest
+++ b/tests/util/numericUTest.cxxtest
@@ -30,12 +30,15 @@ class numericUTest : public CxxTest::TestSuite
 {
 public:
 
-    void test_is_approx_eq_ulp() {
+    void test_is_approx_eq_ulp()
+    {
         double d1 = 0.1,
                d2 = 3,
                d3 = 0.3,
                d4 = d1 * d2;
 
+        cout << "\n";
+        cout << "test_is_approx_eq_ulp:\n";
         cout << setprecision(32) << "d1: " << d1 << endl
                                  << "d2: " << d2 << endl
                                  << "d3: " << d3 << endl
@@ -50,15 +53,40 @@ public:
         TS_ASSERT(not is_approx_eq_ulp(d5,0.0))
     }
 
-    //fixme
-    void test_next_power_of_two() {
+    void test_integer_log2()
+    {
+        unsigned
+            res_0 = integer_log2(0),
+            res_1 = integer_log2(1),
+            res_2 = integer_log2(2),
+            res_3 = integer_log2(3),
+            res_4 = integer_log2(4),
+            res_5 = integer_log2(5);
+
+        cout << "test_integer_log2: ";
+        cout << res_0 << " " << res_1 << " " << res_2 << " "
+             << res_3 << " " << res_4 << " " << res_5 << endl;
+
+        TS_ASSERT_EQUALS(res_0, 0);
+        TS_ASSERT_EQUALS(res_1, 0);
+        TS_ASSERT_EQUALS(res_2, 1);
+        TS_ASSERT_EQUALS(res_3, 1);
+        TS_ASSERT_EQUALS(res_4, 2);
+        TS_ASSERT_EQUALS(res_5, 2);
+    }
+
+    void test_next_power_of_two()
+    {
         TS_ASSERT_THROWS_ANYTHING(next_power_of_two(0));
-        unsigned res_1 = next_power_of_two(1),
+
+        unsigned
+            res_1 = next_power_of_two(1),
             res_2 = next_power_of_two(2),
             res_3 = next_power_of_two(3),
             res_4 = next_power_of_two(4),
             res_5 = next_power_of_two(5);
 
+        cout << "test_next_power_of_two: ";
         cout << res_1 << " " << res_2 << " " << res_3 << " "
              << res_4 << " " << res_5 << endl;
 
@@ -69,25 +97,34 @@ public:
         TS_ASSERT_EQUALS(res_5, 8);
     }
 
-    void test_nbits_to_pack() {
+    void test_nbits_to_pack()
+    {
         TS_ASSERT_THROWS_ANYTHING(nbits_to_pack(0));
-        unsigned res_1 = nbits_to_pack(1),
+        unsigned
+            res_1 = nbits_to_pack(1),
             res_2 = nbits_to_pack(2),
             res_3 = nbits_to_pack(3),
             res_4 = nbits_to_pack(4),
-            res_5 = nbits_to_pack(5);
+            res_5 = nbits_to_pack(5),
+            res_50 = nbits_to_pack(50),
+            res_257 = nbits_to_pack(257);
 
+        cout << "test_nbits_to_pack: ";
         cout << res_1 << " " << res_2 << " " << res_3 << " "
-             << res_4 << " " << res_5 << endl;
+             << res_4 << " " << res_5 << " "
+             << res_50 << " " << res_257 << endl;
 
         TS_ASSERT_EQUALS(res_1, 1);
         TS_ASSERT_EQUALS(res_2, 1);
         TS_ASSERT_EQUALS(res_3, 2);
         TS_ASSERT_EQUALS(res_4, 2);
         TS_ASSERT_EQUALS(res_5, 4);
+        TS_ASSERT_EQUALS(res_50, 8);
+        TS_ASSERT_EQUALS(res_257, 16);
     }
 
-    void test_tanimoto_distance() {
+    void test_tanimoto_distance()
+    {
         typedef vector<float> Vec;
         // test max distance
         {
@@ -135,7 +172,8 @@ public:
         }
     }
 
-    void test_angular_distance() {
+    void test_angular_distance()
+    {
         typedef vector<float> Vec;
         // test max distance
         {
@@ -161,7 +199,7 @@ public:
                 b = {1, 0, 1, 0, 1, 0, 1};
 
             float dst = angular_distance<Vec, float>(a, b, false);
-            TS_ASSERT_DELTA(dst, 2 * acos(2.0 / (sqrt(5 * 4))) / PI, 0.00001);
+            TS_ASSERT_DELTA(dst, 2 * acos(2.0 / (sqrt(5 * 4))) / M_PI, 0.00001);
         }
 
         // test in between distance float
@@ -170,7 +208,7 @@ public:
                 b = {.1, 0, .1, 0, .1, 0, .1};
 
             float dst = angular_distance<Vec, float>(a, b, false);
-            TS_ASSERT_DELTA(dst, 2 * acos(.02 / (sqrt(.05 * .04))) / PI, 0.00001);
+            TS_ASSERT_DELTA(dst, 2 * acos(.02 / (sqrt(.05 * .04))) / M_PI, 0.00001);
         }
 
         // test null case


### PR DESCRIPTION
numeric.h contained a lot of cruft that is now available directly from standard C++

Also: optimize several slow routines for performance.

Also: remove trailing whitespace in all *.h *.cc files