### PR TITLE
Initialize LogWriter::printToStdout to false

### DIFF
--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -150,6 +150,7 @@ Logger::~Logger()
 std::map<std::string, Logger::LogWriter*> Logger::_loggers;
 
 Logger::LogWriter::LogWriter(void)
+	: printToStdout(false)
 {
     writingLoopActive = false;
 #ifdef HAVE_VALGRIND


### PR DESCRIPTION
Otherwise the logger can randomly be initialized to output to stdout