### PR TITLE
Fix set comprehension

### DIFF
--- a/opencog/util/comprehension.h
+++ b/opencog/util/comprehension.h
@@ -114,44 +114,29 @@ auto list_comp(const Container& c, const Function& func,
     return l;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Really weird for set_comp I'm getting the following error (gcc 4.7.3)                                                  //
-//                                                                                                                        //
-// [ 16%] Building CXX object opencog/comboreduct/CMakeFiles/comboreduct.dir/table/table_io.cc.o                          //
-// In file included from /home/nilg/OpenCog/opencog/opencog/comboreduct/table/table_io.cc:36:0:                           //
-// /home/nilg/OpenCog/opencog/opencog/util/comprehension.h:128:8: error: expected type-specifier                          //
-// /home/nilg/OpenCog/opencog/opencog/util/comprehension.h:128:8: error: expected initializer                             //
-// /home/nilg/OpenCog/opencog/opencog/util/comprehension.h:142:8: error: expected type-specifier                          //
-// /home/nilg/OpenCog/opencog/opencog/util/comprehension.h:142:8: error: expected initializer                             //
-//                                                                                                                        //
-// I might be is due to having table_io.cc use both boost and std namespace...                                            //
-//                                                                                                                        //
-// Anyway it's weird enough that I'd rather not even try to attempt fix that for now, I think it might well be a gcc bug. //
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//! set comprehension (STL functor version)
+template<typename Container, typename Function, typename Filter = const_bool>
+auto set_comp(const Container& c, const Function& func,
+              const Filter& filter = default_filter)
+    -> std::set<typename Function::result_type>
+{
+    std::set<typename Function::result_type> s;
+    boost::transform(c | boost::adaptors::filtered(filter),
+                     std::inserter(s, s.end()), func);
+    return s;
+}
 
-/// @todo set comprehension (STL functor version)
-// template<typename Container, typename Function, typename Filter = const_bool>
-// auto set_comp(const Container& c, const Function& func,
-//               const Filter& filter = default_filter)
-//     -> std::set<typename Function::result_type>
-// {
-//     std::set<typename Function::result_type> s;
-//     boost::transform(c | boost::adaptors::filtered(filter),
-//                      std::inserter(s, s.end()), func);
-//     return s;
-// }
-
-/// @todo set comprehension (lambda version)
-// template<typename Container, typename Function, typename Filter = const_bool>
-// auto set_comp(const Container& c, const Function& func,
-//               const Filter& filter = default_filter)
-//     -> std::set<decltype(func(std::declval<typename Container::value_type>()))>
-// {
-//     std::set<decltype(func(std::declval<typename Container::value_type>()))> v;
-//     boost::transform(c | boost::adaptors::filtered(filter),
-//                      std::inserter(v, v.end()), func);
-//     return v;
-// }
+//! set comprehension (lambda version)
+template<typename Container, typename Function, typename Filter = const_bool>
+auto set_comp(const Container& c, const Function& func,
+              const Filter& filter = default_filter)
+    -> std::set<decltype(func(std::declval<typename Container::value_type>()))>
+{
+    std::set<decltype(func(std::declval<typename Container::value_type>()))> v;
+    boost::transform(c | boost::adaptors::filtered(filter),
+                     std::inserter(v, v.end()), func);
+    return v;
+}
 
 }
 

--- a/opencog/util/comprehension.h
+++ b/opencog/util/comprehension.h
@@ -24,6 +24,10 @@
 #ifndef _OPENCOG_COMPREHENSION_H
 #define _OPENCOG_COMPREHENSION_H
 
+#include <vector>
+#include <list>
+#include <set>
+
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 

--- a/tests/util/comprehensionUTest.cxxtest
+++ b/tests/util/comprehensionUTest.cxxtest
@@ -53,13 +53,6 @@ public:
         std::vector<int> evec = {2,4};
         TS_ASSERT_EQUALS(ovec, evec);
     }
-    // void test_vector_comp_phoenix() {
-    //     std::vector<int> ivec = {1,2,3,4};
-    //     auto f = arg1 + 1;
-    //     auto ovec = list_comp(ivec, arg1);
-    //     std::vector<int> evec = {2,3,4,5};
-    //     TS_ASSERT_EQUALS(ovec, evec);
-    // }
     void test_vector_comp_lambda() {
         std::vector<int> ivec = {1,2,3,4};
         auto ovec = vector_comp(ivec, [](int x) { return x + 1; },
@@ -82,13 +75,6 @@ public:
         std::list<int> evec = {2,3,4,5};
         TS_ASSERT_EQUALS(ovec, evec);
     }
-    // void test_list_comp_phoenix() {
-    //     std::list<int> ivec = {1,2,3,4};
-    //     auto f = arg1 + 1;
-    //     auto ovec = list_comp(ivec, arg1);
-    //     std::list<int> evec = {2,3,4,5};
-    //     TS_ASSERT_EQUALS(ovec, evec);
-    // }
     void test_list_comp_lambda() {
         std::list<int> ivec = {1,2,3,4};
         auto ovec = list_comp(ivec, [](int x) { return x + 1; });
@@ -110,13 +96,6 @@ public:
         std::set<int> evec = {2,3,4,5};
         TS_ASSERT_EQUALS(ovec, evec);
     }
-    // void test_set_comp_phoenix() {
-    //     std::set<int> ivec = {1,2,3,4};
-    //     auto f = arg1 + 1;
-    //     auto ovec = set_comp(ivec, arg1);
-    //     std::set<int> evec = {2,3,4,5};
-    //     TS_ASSERT_EQUALS(ovec, evec);
-    // }
     void test_set_comp_lambda() {
         std::set<int> ivec = {1,2,3,4};
         auto ovec = set_comp(ivec, [](int x) { return x + 1; });

--- a/tests/util/comprehensionUTest.cxxtest
+++ b/tests/util/comprehensionUTest.cxxtest
@@ -98,18 +98,18 @@ public:
 
     // Test set comprehension
 
-    // void test_set_comp_function_object() {
-    //     std::set<int> ivec = {1,2,3,4};
-    //     struct Func : public std::unary_function<int, int> {
-    //         int operator()(int i) {
-    //             return i + 1;
-    //         }
-    //     };
-    //     Func func;
-    //     auto ovec = set_comp(ivec, func);
-    //     std::set<int> evec = {2,3,4,5};
-    //     TS_ASSERT_EQUALS(ovec, evec);
-    // }
+    void test_set_comp_function_object() {
+        std::set<int> ivec = {1,2,3,4};
+        struct Func : public std::unary_function<int, int> {
+            int operator()(int i) {
+                return i + 1;
+            }
+        };
+        Func func;
+        auto ovec = set_comp(ivec, func);
+        std::set<int> evec = {2,3,4,5};
+        TS_ASSERT_EQUALS(ovec, evec);
+    }
     // void test_set_comp_phoenix() {
     //     std::set<int> ivec = {1,2,3,4};
     //     auto f = arg1 + 1;
@@ -117,10 +117,10 @@ public:
     //     std::set<int> evec = {2,3,4,5};
     //     TS_ASSERT_EQUALS(ovec, evec);
     // }
-    // void test_set_comp_lambda() {
-    //     std::set<int> ivec = {1,2,3,4};
-    //     auto ovec = set_comp(ivec, [](int x) { return x + 1; });
-    //     std::set<int> evec = {2,3,4,5};
-    //     TS_ASSERT_EQUALS(ovec, evec);
-    // }
+    void test_set_comp_lambda() {
+        std::set<int> ivec = {1,2,3,4};
+        auto ovec = set_comp(ivec, [](int x) { return x + 1; });
+        std::set<int> evec = {2,3,4,5};
+        TS_ASSERT_EQUALS(ovec, evec);
+    }
 };


### PR DESCRIPTION
C++ vector list and set comprehension is back!!! I had partially disable it due to a gcc bug and the bug has been fixed since then.