### PR TITLE
Make build jobs less for moses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           command: mkdir build && cd build && cmake ..
       - run:
           name: Build
-          command: cd build && make -j4
+          command: cd build && make -j2
       - run:
           name: Build tests
           command: cd build && make -j4 tests
@@ -142,7 +142,7 @@ jobs:
           command: mkdir build && cd build && cmake ..
       - run:
           name: Build
-          command: cd build && make -j4
+          command: cd build && make -j2
       - run:
           name: Build tests
           command: cd build && make -j4 tests


### PR DESCRIPTION
Make build jobs less for moses to avoid "c++: internal compiler error: Killed (program cc1plus)" message