### PR TITLE
Add specific check for unix backtrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,15 @@ IF (NOT CXXTEST_FOUND)
 ENDIF (NOT CXXTEST_FOUND)
 
 # -------------------------------------------------------------
+# Look for GNU C++ backtrace. Needed for basic stack printing.
+FIND_PACKAGE(GNUBacktrace)
+IF (GNU_BACKTRACE_FOUND)
+	ADD_DEFINITIONS(-DHAVE_GNU_BACKTRACE)
+ELSE (GNU_BACKTRACE_FOUND)
+	MESSAGE(STATUS "GNU backtrace missing: No basic stack-trace printing.")
+ENDIF (GNU_BACKTRACE_FOUND)
+
+# -------------------------------------------------------------
 # Look for binutils-dev. Needed for pretty stack printing.
 FIND_PACKAGE(BFD)
 IF (BFD_FOUND)

--- a/cmake/FindGNUBacktrace.cmake
+++ b/cmake/FindGNUBacktrace.cmake
@@ -1,0 +1,14 @@
+INCLUDE ( CheckIncludeFile )
+INCLUDE ( CheckIncludeFileCXX )
+CHECK_INCLUDE_FILE_CXX ( cxxabi.h HAVE_CXXABI_H )
+CHECK_INCLUDE_FILE ( execinfo.h HAVE_EXECINFO_H )
+
+if ( HAVE_EXECINFO_H AND HAVE_CXXABI_H )
+	set( GNU_BACKTRACE_FOUND TRUE )
+endif ( HAVE_EXECINFO_H AND HAVE_CXXABI_H )
+
+if ( GNU_BACKTRACE_FOUND )
+	message( STATUS "Found GNU execinfo.h C++ backtrace functionality")
+else ( GNU_BACKTRACE_FOUND )
+	message( STATUS "GNU execinfo.h C++ backtrace functionality not found")
+endif ( GNU_BACKTRACE_FOUND )

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -27,7 +27,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef CYGWIN
+#if defined(HAVE_GNU_BACKTRACE)
 #include <cxxabi.h>
 #include <execinfo.h>
 #endif
@@ -68,8 +68,8 @@ using namespace opencog;
 #define MAX_PRINTF_STYLE_MESSAGE_SIZE (1<<15)
 const char* levelStrings[] = {"NONE", "ERROR", "WARN", "INFO", "DEBUG", "FINE"};
 
-#ifndef CYGWIN /// @todo backtrace and backtrace_symbols is UNIX, we
-              /// may need a WIN32 version
+#if defined(HAVE_GNU_BACKTRACE) /// @todo backtrace and backtrace_symbols
+                                /// is LINUX, we may need a WIN32 version
 static void prt_backtrace(std::ostringstream& oss)
 {
 #define BT_BUFSZ 50
@@ -461,7 +461,7 @@ void Logger::log(Logger::Level level, const std::string &txt)
 
     oss << txt << std::endl;
 
-#ifndef CYGWIN
+#if defined(HAVE_GNU_BACKTRACE)
     if (level <= backTraceLevel)
     {
         prt_backtrace(oss);
@@ -490,7 +490,7 @@ void Logger::backtrace()
     static const unsigned int max_queue_size_allowed = 1024;
     std::ostringstream oss;
 
-    #ifndef CYGWIN
+    #if defined(HAVE_GNU_BACKTRACE)
     prt_backtrace(oss);
     #endif
 

--- a/opencog/util/backtrace-symbols.h
+++ b/opencog/util/backtrace-symbols.h
@@ -9,14 +9,12 @@ extern "C" {
 #if defined(HAVE_BFD) && defined(HAVE_IBERTY)
 char **oc_backtrace_symbols(void *const *buffer, int size);
 void oc_backtrace_symbols_fd(void *const *buffer, int size, int fd);
-#else
-#ifndef CYGWIN
+#elif defined(HAVE_GNU_BACKTRACE)
 #include <execinfo.h>
 char **oc_backtrace_symbols(void *const *buffer, int size) {
 	return backtrace_symbols(buffer, size); }
 void oc_backtrace_symbols_fd(void *const *buffer, int size, int fd) {
 	backtrace_symbols_fd(buffer, size, fd); }
-#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Aids building on other platforms than just apple and cygwin, that lack this.