### PR TITLE
clang-compatible fgetc return type

### DIFF
--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -100,7 +100,7 @@ public:
         TS_ASSERT(f1 != NULL);
         TS_ASSERT(f2 != NULL);
 
-        char c1 = fgetc(f1);
+        int c1 = fgetc(f1);
         while (c1 != EOF)
         {
             char c2 = fgetc(f2);


### PR DESCRIPTION
Clang assumes `char == -1` is always false, so this change to respect the `fgetc` function signature better allows the loop to complete and the test to pass on my system.