### PR TITLE
respect TMPDIR in LoggerUTest

### DIFF
--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -27,6 +27,7 @@
 #include <unistd.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -72,11 +73,18 @@ public:
 
     void testLog()
     {
+        char const * tmpdir;
         char baselineFile[256];
         char logFile[256];
 
-        strcpy(baselineFile, "/tmp/testLogBaseline.txt");
-        strcpy(logFile, "/tmp/testLog.txt");
+	tmpdir = getenv("TMPDIR");
+	if (tmpdir == nullptr) tmpdir = "/tmp";
+
+	strcpy(baselineFile, tmpdir);
+	strcpy(logFile, tmpdir);
+
+        strcat(baselineFile, "/testLogBaseline.txt");
+        strcat(logFile, "/testLog.txt");
 
         Logger baseline(baselineFile, Logger::FINE, false);
         Logger _logger(logFile, Logger::DEBUG, false);


### PR DESCRIPTION
Required for test to pass when `/tmp` is not writable.