### PR TITLE
Move printToStdout out of the log writer

### DIFF
--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -314,6 +314,7 @@ private:
     bool timestampEnabled;
     bool threadIdEnabled;
     bool logEnabled;
+    bool printToStdout;
     bool printLevel;
     bool syncEnabled;
 
@@ -348,8 +349,6 @@ private:
         void write_msg(const std::string&);
 
     public:
-        bool printToStdout;
-
         LogWriter(void);
         ~LogWriter();
 

--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -77,11 +77,11 @@ public:
         char baselineFile[256];
         char logFile[256];
 
-	tmpdir = getenv("TMPDIR");
-	if (tmpdir == nullptr) tmpdir = "/tmp";
+        tmpdir = getenv("TMPDIR");
+        if (tmpdir == nullptr) tmpdir = "/tmp";
 
-	strcpy(baselineFile, tmpdir);
-	strcpy(logFile, tmpdir);
+        strcpy(baselineFile, tmpdir);
+        strcpy(logFile, tmpdir);
 
         strcat(baselineFile, "/testLogBaseline.txt");
         strcat(logFile, "/testLog.txt");
@@ -284,7 +284,7 @@ public:
     // whether the stdout in the other logger is left unchanged.
     //
     // TODO: re-enabled once fixed
-    void xtestLoggerStdoutFlagInteraction()
+    void testLoggerStdoutFlagInteraction()
     {
         Logger my_logger;
 


### PR DESCRIPTION
So that each logger can set this flag independently of the other
loggers, regardless of whether they share the same log file.

Fix for issue https://github.com/opencog/cogutil/issues/195