### PR TITLE
Logger safety precautions

### DIFF
--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -179,10 +179,7 @@ void Logger::LogWriter::start_write_loop()
 {
     std::unique_lock<std::mutex> lock(the_mutex);
     if (!writingLoopActive)
-    {
-        writingLoopActive = true;
         writer_thread = std::thread(&Logger::LogWriter::writing_loop, this);
-    }
 }
 
 void Logger::LogWriter::stop_write_loop()
@@ -191,11 +188,11 @@ void Logger::LogWriter::stop_write_loop()
     msg_queue.cancel();
     // rejoin thread
     writer_thread.join();
-    writingLoopActive = false;
 }
 
 void Logger::LogWriter::writing_loop()
 {
+    writingLoopActive = true;
     try
     {
         while (true)
@@ -211,9 +208,9 @@ void Logger::LogWriter::writing_loop()
     }
     catch (concurrent_queue< std::string* >::Canceled &e)
     {
-        pending_write = false;
-        return;
     }
+    pending_write = false;
+    writingLoopActive = false;
 }
 
 void Logger::flush()

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -147,6 +147,7 @@ Logger::~Logger()
     if (_log_writer) _log_writer->flush();
 }
 
+std::mutex Logger::_loggers_mtx;
 std::map<std::string, Logger::LogWriter*> Logger::_loggers;
 
 Logger::LogWriter::LogWriter(void)
@@ -360,6 +361,7 @@ void Logger::LogWriter::setFileName(const std::string& s)
 
 void Logger::set_filename(const std::string& fname)
 {
+    std::lock_guard<std::mutex> lock(_loggers_mtx);
     try {
         _log_writer = _loggers.at(fname);
     }
@@ -370,6 +372,15 @@ void Logger::set_filename(const std::string& fname)
     }
 
     enable();
+}
+
+LogWriter* Logger::get_log_writer(const std::string& fname)
+{
+    std::lock_guard<std::mutex> lock(_loggers_mtx);
+    LogWriter* wr = nullptr;
+    try { wr = _loggers.at(fname); }
+    catch (...) {}
+    return wr;
 }
 
 const std::string& Logger::get_filename() const

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -603,6 +603,7 @@ Logger& opencog::logger()
 
 /// Destroy all active loggers on exit. The destructor will
 /// flush all messages to the logs, and close the logfile.
+/// The corresponding writer thread will disappear as well.
 void Logger::on_exit()
 {
     std::lock_guard<std::mutex> lock(_loggers_mtx);

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -253,11 +253,26 @@ void Logger::LogWriter::write_msg(const std::string &msg)
     }
 
     // Write to file.
-    fprintf(logfile, "%s", msg.c_str());
+    int rc = fprintf(logfile, "%s", msg.c_str());
+    if ((int) msg.size() != rc)
+    {
+        fprintf(stderr,
+            "[ERROR] failed write to logfile, rc=%d sz=%lu\n",
+            rc, msg.size());
+        exit(1);
+    }
 
     // Flush, because log messages are important, especially if we
     // are about to crash. So we don't want to have these buffered up.
-    fflush(logfile);
+    rc = fflush(logfile);
+    if (0 != rc)
+    {
+        int norr = errno;
+        fprintf(stderr,
+            "[ERROR] failed to flush logfile, rc=%d errno=%d %s\n",
+            rc, norr, strerror(norr));
+        exit(1);
+    }
 }
 
 Logger::Logger(const std::string &fname, Logger::Level level, bool tsEnabled)

--- a/opencog/util/Logger.cc
+++ b/opencog/util/Logger.cc
@@ -594,9 +594,26 @@ Logger::Level Logger::get_level_from_string(const std::string& levelStr)
     return BAD_LEVEL;
 }
 
-// Create and return the single instance
+/// Create and return the single instance
 Logger& opencog::logger()
 {
     static Logger instance;
     return instance;
+}
+
+/// Destroy all active loggers on exit. The destructor will
+/// flush all messages to the logs, and close the logfile.
+void Logger::on_exit()
+{
+    std::lock_guard<std::mutex> lock(_loggers_mtx);
+    for (auto wrtr: _loggers)
+    {
+        delete wrtr.second;
+    }
+    _loggers.clear();
+}
+
+static __attribute__ ((destructor)) void _fini(void)
+{
+   Logger::on_exit();
 }

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -48,8 +48,6 @@ class Logger
     void set(const Logger&);
 public:
 
-    // WARNING: if you change the levels don't forget to update
-    // levelStrings[] in Logger.cc
     enum Level { NONE, ERROR, WARN, INFO, DEBUG, FINE, BAD_LEVEL=255 };
 
     /**

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -368,11 +368,8 @@ private:
 
     LogWriter* _log_writer;
 
-    // Please use the mutex! Either that, or fix your code to use
-    // get_log_writer() instead!
     static std::mutex _loggers_mtx;
     static std::map<std::string, LogWriter*> _loggers;
-    static LogWriter* get_log_writer(std::string);
 
 }; // class
 

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -368,8 +368,8 @@ private:
 
     LogWriter* _log_writer;
 
-    static std::mutex * _loggers_mtx;
-    static std::map<std::string, LogWriter*> * _loggers;
+    static std::mutex _loggers_mtx;
+    static std::map<std::string, LogWriter*> _loggers;
 
 }; // class
 

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -306,6 +306,7 @@ public:
      */
     void flush();
 
+    static void on_exit();
 private:
 
     std::string component;
@@ -376,7 +377,7 @@ private:
 // A singleton instance is enough for most users.
 Logger& logger();
 
-// Macros to not evaluate the stream if log level is disabled
+// Macros that avoid evaluating the stream if the log-level is disabled
 #define LAZY_LOG_ERROR if(logger().is_error_enabled()) logger().error()
 #define LAZY_LOG_WARN if(logger().is_warn_enabled()) logger().warn()
 #define LAZY_LOG_INFO if(logger().is_info_enabled()) logger().info()

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -367,7 +367,12 @@ private:
     };
 
     LogWriter* _log_writer;
+
+    // Please use the mutex! Either that, or fix your code to use
+    // get_log_writer() instead!
+    static std::mutex _loggers_mtx;
     static std::map<std::string, LogWriter*> _loggers;
+    static LogWriter* get_log_writer(std::string);
 
 }; // class
 

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -304,6 +304,7 @@ public:
      */
     void flush();
 
+    static void on_load();
     static void on_exit();
 private:
 
@@ -367,8 +368,8 @@ private:
 
     LogWriter* _log_writer;
 
-    static std::mutex _loggers_mtx;
-    static std::map<std::string, LogWriter*> _loggers;
+    static std::mutex * _loggers_mtx;
+    static std::map<std::string, LogWriter*> * _loggers;
 
 }; // class
 

--- a/opencog/util/async_buffer.h
+++ b/opencog/util/async_buffer.h
@@ -301,7 +301,7 @@ void async_buffer<Writer, Element>::stop_writer_threads()
 	_store_set.cancel_reset();
 	while (not _store_set.is_empty())
 	{
-		Element elt = _store_set.get();
+		Element elt = _store_set.value_get();
 		(_writer->*_do_write)(elt);
 	}
 	
@@ -381,7 +381,7 @@ void async_buffer<Writer, Element>::write_loop()
 				std::this_thread::sleep_for(std::chrono::milliseconds(3));
 			}
 
-			Element elt = _store_set.get();
+			Element elt = _store_set.value_get();
 			_busy_writers ++; // Bad -- window after get returns, before increment!
 			(_writer->*_do_write)(elt);
 			_busy_writers --;

--- a/opencog/util/concurrent_queue.h
+++ b/opencog/util/concurrent_queue.h
@@ -73,9 +73,12 @@ private:
     concurrent_queue& operator=(const concurrent_queue&) = delete; // no assign
 
 public:
-    concurrent_queue()
+    concurrent_queue(void)
         : the_queue(), the_mutex(), the_cond(), is_canceled(false)
     {}
+    ~concurrent_queue()
+    { if (not is_canceled) cancel(); }
+
     struct Canceled : public std::exception
     {
         const char * what() { return "Cancellation of wait on concurrent_queue"; }

--- a/opencog/util/concurrent_queue.h
+++ b/opencog/util/concurrent_queue.h
@@ -172,6 +172,11 @@ public:
         return value;
     }
 
+    /// XXX DO NOT USE! This has a C++ signature incompatible with
+    /// the other pop, immediately above, thus wrecking automatic
+    /// C++ overloading!
+    Element pop() { return value_pop(); }
+
     std::deque<Element> wait_and_take_all()
     {
         std::unique_lock<std::mutex> lock(the_mutex);

--- a/opencog/util/concurrent_queue.h
+++ b/opencog/util/concurrent_queue.h
@@ -10,9 +10,9 @@
  * ISO/IEC JTC1 SC22 WG21 P0260R3 C++ Concurrent Queues
  *
  * This differs from P0260R3 in that:
- * 1) There is no open or close
- * 2) The queue here is unbounded in size
- * 3) It doesn't have iterators
+ * 1) The queue here is unbounded in size
+ * 2) It doesn't have iterators
+ * 3) There is no try_put()
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License v3 as
@@ -226,6 +226,7 @@ public:
        std::lock_guard<std::mutex> lock(the_mutex);
        is_canceled = false;
     }
+    void open() { cancel_reset(); }
 
     void cancel()
     {
@@ -235,6 +236,9 @@ public:
        lock.unlock();
        the_cond.notify_all();
     }
+    void close() { cancel(); }
+
+    bool is_closed() const noexcept { return is_canceled; }
 
     static bool is_lock_free() noexcept { return false; }
 };

--- a/opencog/util/concurrent_queue.h
+++ b/opencog/util/concurrent_queue.h
@@ -105,7 +105,7 @@ public:
     /// Since other threads may have pushed or popped immediately
     /// after this call, the emptiness of the queue may have
     /// changed by the time the caller looks at it.
-    bool is_empty() const noexcept
+    bool is_empty() const
     {
         std::lock_guard<std::mutex> lock(the_mutex);
         if (is_canceled) throw Canceled();

--- a/opencog/util/concurrent_set.h
+++ b/opencog/util/concurrent_set.h
@@ -118,7 +118,7 @@ public:
     /// Since other threads may have inserted or removed immediately
     /// after this call, the emptiness of the set may have
     /// changed by the time the caller looks at it.
-    bool is_empty() const noexcept
+    bool is_empty() const
     {
         std::lock_guard<std::mutex> lock(the_mutex);
         if (is_canceled) throw Canceled();

--- a/opencog/util/concurrent_set.h
+++ b/opencog/util/concurrent_set.h
@@ -10,9 +10,9 @@
  * ISO/IEC JTC1 SC22 WG21 P0260R3 C++ Concurrent Queues
  *
  * This differs from P0260R3 in that:
- * 1) There is no open or close
- * 2) The set here is unbounded in size
- * 3) It doesn't have iterators
+ * 1) The set here is unbounded in size
+ * 2) It doesn't have iterators
+ * 3) There is no try_put()
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License v3 as
@@ -234,6 +234,7 @@ public:
        std::lock_guard<std::mutex> lock(the_mutex);
        is_canceled = false;
     }
+    void open() { cancel_reset(); }
 
     void cancel()
     {
@@ -243,6 +244,9 @@ public:
        lock.unlock();
        the_cond.notify_all();
     }
+    void close() { cancel(); }
+
+    bool is_closed() const noexcept { return is_canceled; }
 
     static bool is_lock_free() noexcept { return false; }
 };

--- a/opencog/util/concurrent_set.h
+++ b/opencog/util/concurrent_set.h
@@ -85,9 +85,11 @@ private:
     concurrent_set& operator=(const concurrent_set&) = delete; // no assign
 
 public:
-    concurrent_set()
+    concurrent_set(void)
         : the_set(), the_mutex(), the_cond(), is_canceled(false)
     {}
+    ~concurrent_set()
+    { if (not is_canceled) cancel(); }
 
     struct Canceled : public std::exception
     {

--- a/opencog/util/concurrent_stack.h
+++ b/opencog/util/concurrent_stack.h
@@ -174,6 +174,11 @@ public:
         return value;
     }
 
+    /// XXX DO NOT USE! This has a C++ signature incompatible with
+    /// the other pop, immediately above, thus wrecking automatic
+    /// C++ overloading!
+    Element pop() { return value_pop(); }
+
     std::stack<Element> wait_and_take_all()
     {
         std::unique_lock<std::mutex> lock(the_mutex);

--- a/opencog/util/concurrent_stack.h
+++ b/opencog/util/concurrent_stack.h
@@ -106,7 +106,7 @@ public:
     /// Since other threads may have pushed or popped immediately
     /// after this call, the emptiness of the stack may have
     /// changed by the time the caller looks at it.
-    bool is_empty() const noexcept
+    bool is_empty() const
     {
         std::lock_guard<std::mutex> lock(the_mutex);
         if (is_canceled) throw Canceled();

--- a/opencog/util/concurrent_stack.h
+++ b/opencog/util/concurrent_stack.h
@@ -73,9 +73,11 @@ private:
     concurrent_stack& operator=(const concurrent_stack&) = delete; // no assign
 
 public:
-    concurrent_stack()
+    concurrent_stack(void)
         : the_stack(), the_mutex(), the_cond(), is_canceled(false)
     {}
+    ~concurrent_stack()
+    { if (not is_canceled) cancel(); }
 
     struct Canceled : public std::exception
     {

--- a/opencog/util/concurrent_stack.h
+++ b/opencog/util/concurrent_stack.h
@@ -10,9 +10,9 @@
  * ISO/IEC JTC1 SC22 WG21 P0260R3 C++ Concurrent Queues
  *
  * This differs from P0260R3 in that:
- * 1) There is no open or close
- * 2) The stack here is unbounded in size
- * 3) It doesn't have iterators
+ * 1) The stack here is unbounded in size
+ * 2) It doesn't have iterators
+ * 3) There is no try_put()
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License v3 as
@@ -220,6 +220,7 @@ public:
        std::lock_guard<std::mutex> lock(the_mutex);
        is_canceled = false;
     }
+    void open() { cancel_reset(); }
 
     void cancel()
     {
@@ -229,6 +230,9 @@ public:
        lock.unlock();
        the_cond.notify_all();
     }
+    void close() { cancel(); }
+
+    bool is_closed() const noexcept { return is_canceled; }
 
     static bool is_lock_free() noexcept { return false; }
 };


### PR DESCRIPTION
Tighten up logger usage, per logger malfunction in issue opencog/atomspace#2371

To be clear: when processes are run in rapid succession, each process opening the same log file, writing to it, and then deleting it, then exiting, there are several nasty issues: 

1) the file delete might not be complete before the next file-open starts, resulting in duplicated content in the log file (I'm assuming that the duplicated content is from the earlier log-file writes.)

2) If the log file is not deleted, it can still happen that writing might not be completed when the process exits, resulting in lost output.

Between 1&2 above, log files can have duplicated content and also be incomplete.  Thoroughly crazy-making for debug.