### PR TITLE
There's no need to check for unused packages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,7 @@ SET(MIN_BOOST 1.46)
 
 # Required boost packages
 # 1.46 is minimum for required filesystem support
-# program_options needed by some combo utilities
-FIND_PACKAGE(Boost ${MIN_BOOST} COMPONENTS date_time filesystem program_options regex serialization system thread REQUIRED)
+FIND_PACKAGE(Boost ${MIN_BOOST} COMPONENTS filesystem program_options system thread REQUIRED)
 
 IF (Boost_FOUND)
 	SET(Boost_FOUND_SAVE 1)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ container in which OpenCog will be built and run.
 
 ###### boost
 > C++ utilities package
-> http://www.boost.org/ | libboost-dev, libboost-date-time-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-regex-dev, libboost-serialization-dev, libboost-system-dev, libboost-thread-dev
+> http://www.boost.org/ | libboost-dev, libboost-program-options-dev, libboost-system-dev, libboost-thread-dev
 
 ###### cmake
 > Build management tool; v2.8 or higher recommended.


### PR DESCRIPTION
Attempting to debug the cogserver ShellUTest crash ... I suspect it's boost badness...