### PR TITLE
Bug-fix missing parallel support.

### DIFF
--- a/opencog/util/oc_omp.h
+++ b/opencog/util/oc_omp.h
@@ -46,7 +46,7 @@
 //! compile with multithread support (!)
 #if defined(CYGWIN)
 #elif defined(__APPLE__)
-#elif HAVE_PARALLEL_STL
+#elif HAVE_PARALLEL_ALGORITHM
 #define OC_OMP
 #endif
 


### PR DESCRIPTION
The CMakefile calls this `HAVE_PARALLEL_ALGORITHM` not `HAVE_PARALLEL_STL`