### PR TITLE
Ubuntu 20.04 binutils API fix

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+Language: Cpp
+BreakBeforeBraces: Linux
+IndentCaseLabels: true
+IndentPPDirectives: BeforeHash
+ColumnLimit: 100
+AllowShortIfStatementsOnASingleLine: true

--- a/opencog/util/backtrace-symbols.c
+++ b/opencog/util/backtrace-symbols.c
@@ -49,64 +49,59 @@
 
 #if defined(HAVE_BFD) && defined(HAVE_IBERTY)
 
-#include "backtrace-symbols.h"
+    #include "backtrace-symbols.h"
 
-#define fatal(a, b) exit(1)
-#define bfd_fatal(a) exit(1)
-#define bfd_nonfatal(a) exit(1)
-#define list_matching_formats(a) exit(1)
+    #define fatal(a, b) exit(1)
+    #define bfd_fatal(a) exit(1)
+    #define bfd_nonfatal(a) exit(1)
+    #define list_matching_formats(a) exit(1)
 
-/* 2 characters for each byte, plus 1 each for 0, x, and NULL */
-#define PTRSTR_LEN (sizeof(void *) * 2 + 3)
-#define true 1
-#define false 0
+    /* 2 characters for each byte, plus 1 each for 0, x, and NULL */
+    #define PTRSTR_LEN (sizeof(void *) * 2 + 3)
+    #define true 1
+    #define false 0
 
-#define _GNU_SOURCE
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#ifndef CYGWIN
-#include <execinfo.h>
-#endif
-#include <libiberty.h> // must appear before bfd.h !! see bug #696
-//  https://github.com/opencog/opencog/issues/696
-#include <bfd.h>
-#include <dlfcn.h>
-#include <link.h>
-#include <pthread.h>
+    #define _GNU_SOURCE
+    #include <stdio.h>
+    #include <stdlib.h>
+    #include <string.h>
+    #ifndef CYGWIN
+        #include <execinfo.h>
+    #endif
+    #include <libiberty.h> // must appear before bfd.h !! see bug #696
+    //  https://github.com/opencog/opencog/issues/696
+    #include <bfd.h>
+    #include <dlfcn.h>
+    #include <link.h>
+    #include <pthread.h>
 
-/* 150 isn't special; it's just an arbitrary non-ASCII char value.  */
-#define OPTION_DEMANGLER      (150)
+    /* 150 isn't special; it's just an arbitrary non-ASCII char value.  */
+    #define OPTION_DEMANGLER (150)
 
 /* Read in the symbol table.  */
 
-static void slurp_symtab(bfd * abfd, asymbol **syms)
+static void slurp_symtab(bfd *abfd, asymbol **syms)
 {
-      long symcount;
-      unsigned int size;
+    long symcount;
+    unsigned int size;
 
-      if ((bfd_get_file_flags(abfd) & HAS_SYMS) == 0)
-            return;
+    if ((bfd_get_file_flags(abfd) & HAS_SYMS) == 0) return;
 
-      symcount = bfd_read_minisymbols(abfd, false, (PTR) & syms, &size);
-      if (symcount == 0)
-            symcount = bfd_read_minisymbols(abfd, true /* dynamic */ ,
-                                    (PTR) & syms, &size);
+    symcount = bfd_read_minisymbols(abfd, false, (PTR)&syms, &size);
+    if (symcount == 0) symcount = bfd_read_minisymbols(abfd, true /* dynamic */, (PTR)&syms, &size);
 
-      if (symcount < 0)
-            bfd_fatal(bfd_get_filename(abfd));
+    if (symcount < 0) bfd_fatal(bfd_get_filename(abfd));
 }
 
 /* These variables are used to pass information between
    translate_addresses and find_address_in_section.  */
-struct spotty
-{
-      asymbol **syms;
-      bfd_vma pc;
-      const char *filename;
-      const char *functionname;
-      unsigned int line;
-      int found;
+struct spotty {
+    asymbol **syms;
+    bfd_vma pc;
+    const char *filename;
+    const char *functionname;
+    unsigned int line;
+    int found;
 };
 
 /* Look for an address in a section.  This is called via
@@ -114,226 +109,218 @@ struct spotty
 
 static void find_address_in_section(bfd *abfd, asection *section, void *data)
 {
-      struct spotty *spot = (struct spotty *) data;
-      bfd_vma vma;
-      bfd_size_type size;
+    struct spotty *spot = (struct spotty *)data;
+    bfd_vma vma;
+    bfd_size_type size;
 
-      if (spot->found)
-            return;
+    if (spot->found) return;
 
-      if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0)
-            return;
+    if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0) return;
 
-      vma = bfd_get_section_vma(abfd, section);
-      if (spot->pc < vma)
-            return;
+    vma = bfd_get_section_vma(abfd, section);
+    if (spot->pc < vma) return;
 
-      size = bfd_section_size(abfd, section);
-      if (spot->pc >= vma + size)
-            return;
+    size = bfd_section_size(section);
+    if (spot->pc >= vma + size) return;
 
-      spot->found = bfd_find_nearest_line(abfd, section, spot->syms, spot->pc - vma,
-                              &(spot->filename), &(spot->functionname), &(spot->line));
+    spot->found = bfd_find_nearest_line(abfd, section, spot->syms, spot->pc - vma,
+                                        &(spot->filename), &(spot->functionname), &(spot->line));
 }
 
-static char** translate_addresses_buf(bfd * abfd, bfd_vma *addr, int naddr, asymbol** syms)
+static char **translate_addresses_buf(bfd *abfd, bfd_vma *addr, int naddr, asymbol **syms)
 {
-      int naddr_orig = naddr;
-      char b;
-      int total  = 0;
-      enum { Count, Print } state;
-      char *buf = &b;
-      int len = 0;
-      char **ret_buf = NULL;
+    int naddr_orig = naddr;
+    char b;
+    int total = 0;
+    enum { Count, Print } state;
+    char *buf = &b;
+    int len = 0;
+    char **ret_buf = NULL;
 
-      struct spotty spot;
-      spot.syms = syms;
+    struct spotty spot;
+    spot.syms = syms;
 
-      /* iterate over the formating twice.
-       * the first time we count how much space we need
-       * the second time we do the actual printing */
-      for (state=Count; state<=Print; state++) {
-      if (state == Print) {
-            ret_buf = malloc(total + sizeof(char*) * naddr);
-            buf = (char*)(ret_buf + naddr);
+    /* iterate over the formating twice.
+     * the first time we count how much space we need
+     * the second time we do the actual printing */
+    for (state = Count; state <= Print; state++) {
+        if (state == Print) {
+            ret_buf = malloc(total + sizeof(char *) * naddr);
+            buf = (char *)(ret_buf + naddr);
             len = total;
-      }
-      while (naddr) {
-            if (state == Print)
-                  ret_buf[naddr-1] = buf;
-            spot.pc = addr[naddr-1];
+        }
+        while (naddr) {
+            if (state == Print) ret_buf[naddr - 1] = buf;
+            spot.pc = addr[naddr - 1];
 
             spot.found = false;
-            bfd_map_over_sections(abfd, find_address_in_section, (PTR) &spot);
+            bfd_map_over_sections(abfd, find_address_in_section, (PTR)&spot);
 
             if (!spot.found) {
-                  total += snprintf(buf, len, "[0x%llx] \?\?() \?\?:0", (long long unsigned int) addr[naddr-1]) + 1;
+                total += snprintf(buf, len, "[0x%llx] \?\?() \?\?:0",
+                                  (long long unsigned int)addr[naddr - 1]) +
+                         1;
             } else {
-                  const char *name;
+                const char *name;
 
-                  name = spot.functionname;
-                  if (name == NULL || *name == '\0')
-                        name = "??";
-                  if (spot.filename != NULL) {
-                        char *h;
+                name = spot.functionname;
+                if (name == NULL || *name == '\0') name = "??";
+                if (spot.filename != NULL) {
+                    char *h;
 
-                        h = strrchr(spot.filename, '/');
-                        if (h != NULL)
-                              spot.filename = h + 1;
-                  }
-                  total += snprintf(buf, len, "%s:%u\t%s()", spot.filename ? spot.filename : "??",
-                         spot.line, name) + 1;
-
+                    h = strrchr(spot.filename, '/');
+                    if (h != NULL) spot.filename = h + 1;
+                }
+                total += snprintf(buf, len, "%s:%u\t%s()", spot.filename ? spot.filename : "??",
+                                  spot.line, name) +
+                         1;
             }
             if (state == Print) {
-                  /* set buf just past the end of string */
-                  buf = buf + total + 1;
+                /* set buf just past the end of string */
+                buf = buf + total + 1;
             }
             naddr--;
-      }
-      naddr = naddr_orig;
-      }
-      return ret_buf;
+        }
+        naddr = naddr_orig;
+    }
+    return ret_buf;
 }
 /* Process a file.  */
 
 static char **process_file(const char *file_name, bfd_vma *addr, int naddr)
 {
-      bfd *abfd = NULL;
-      char **matching = NULL;
-      char **ret_buf = NULL;
-      asymbol **syms = NULL;      /* Symbol table */
+    bfd *abfd = NULL;
+    char **matching = NULL;
+    char **ret_buf = NULL;
+    asymbol **syms = NULL; /* Symbol table */
 
-      abfd = bfd_openr(file_name, NULL);
+    abfd = bfd_openr(file_name, NULL);
 
-      if (abfd == NULL)
-            bfd_fatal(file_name);
+    if (abfd == NULL) bfd_fatal(file_name);
 
-      if (bfd_check_format(abfd, bfd_archive))
-            fatal("%s: can not get addresses from archive", file_name);
+    if (bfd_check_format(abfd, bfd_archive))
+        fatal("%s: can not get addresses from archive", file_name);
 
-      if (!bfd_check_format_matches(abfd, bfd_object, &matching)) {
-            bfd_nonfatal(bfd_get_filename(abfd));
-            if (bfd_get_error() ==
-                bfd_error_file_ambiguously_recognized) {
-                  list_matching_formats(matching);
-                  free(matching);
-            }
-            xexit(1);
-      }
+    if (!bfd_check_format_matches(abfd, bfd_object, &matching)) {
+        bfd_nonfatal(bfd_get_filename(abfd));
+        if (bfd_get_error() == bfd_error_file_ambiguously_recognized) {
+            list_matching_formats(matching);
+            free(matching);
+        }
+        xexit(1);
+    }
 
-      slurp_symtab(abfd, syms);
+    slurp_symtab(abfd, syms);
 
-      ret_buf = translate_addresses_buf(abfd, addr, naddr, syms);
+    ret_buf = translate_addresses_buf(abfd, addr, naddr, syms);
 
-      if (syms != NULL) {
-            free(syms);
-            syms = NULL;
-      }
+    if (syms != NULL) {
+        free(syms);
+        syms = NULL;
+    }
 
-      bfd_close(abfd);
-      return ret_buf;
+    bfd_close(abfd);
+    return ret_buf;
 }
 
-#define MAX_DEPTH 16
+    #define MAX_DEPTH 16
 
 struct file_match {
-      const char *file;
-      void *address;
-      void *base;
-      void *hdr;
+    const char *file;
+    void *address;
+    void *base;
+    void *hdr;
 };
 
-static int find_matching_file(struct dl_phdr_info *info,
-            size_t size, void *data)
+static int find_matching_file(struct dl_phdr_info *info, size_t size, void *data)
 {
-      struct file_match *match = data;
-      /* This code is modeled from Gfind_proc_info-lsb.c:callback() from libunwind */
-      long n;
-      const ElfW(Phdr) *phdr;
-      ElfW(Addr) load_base = info->dlpi_addr;
-      phdr = info->dlpi_phdr;
-      for (n = info->dlpi_phnum; --n >= 0; phdr++) {
-            if (phdr->p_type == PT_LOAD) {
-                  ElfW(Addr) vaddr = phdr->p_vaddr + load_base;
-                  ElfW(Addr) match_address = (ElfW(Addr)) match->address;
-                  if (match_address >= vaddr && match_address < vaddr + phdr->p_memsz) {
-                        /* we found a match */
-                        match->file = info->dlpi_name;
-                        match->base = (void *) info->dlpi_addr;
-                  }
+    struct file_match *match = data;
+    /* This code is modeled from Gfind_proc_info-lsb.c:callback() from libunwind
+     */
+    long n;
+    const ElfW(Phdr) * phdr;
+    ElfW(Addr) load_base = info->dlpi_addr;
+    phdr = info->dlpi_phdr;
+    for (n = info->dlpi_phnum; --n >= 0; phdr++) {
+        if (phdr->p_type == PT_LOAD) {
+            ElfW(Addr) vaddr = phdr->p_vaddr + load_base;
+            ElfW(Addr) match_address = (ElfW(Addr))match->address;
+            if (match_address >= vaddr && match_address < vaddr + phdr->p_memsz) {
+                /* we found a match */
+                match->file = info->dlpi_name;
+                match->base = (void *)info->dlpi_addr;
             }
-      }
-      return 0;
+        }
+    }
+    return 0;
 }
 
 char **oc_backtrace_symbols(void *const *buffer, int size)
 {
-      static pthread_mutex_t bfd_mutex = PTHREAD_MUTEX_INITIALIZER;
+    static pthread_mutex_t bfd_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-      int stack_depth = size - 1;
-      int x,y;
-      /* discard calling function */
-      int total = 0;
+    int stack_depth = size - 1;
+    int x, y;
+    /* discard calling function */
+    int total = 0;
 
-      char ***locations;
-      char **final;
-      char *f_strings;
+    char ***locations;
+    char **final;
+    char *f_strings;
 
-      locations = malloc(sizeof(char**) * (stack_depth+1));
+    locations = malloc(sizeof(char **) * (stack_depth + 1));
 
-      pthread_mutex_lock(&bfd_mutex);
-      bfd_init();
-      for (x=stack_depth, y=0; x>=0; x--, y++) {
-            struct file_match match = { .address = buffer[x] };
-            char **ret_buf;
-            bfd_vma addr;
-            dl_iterate_phdr(find_matching_file, &match);
-            addr = buffer[x] - match.base;
-            if (match.file && strlen(match.file))
-                  ret_buf = process_file(match.file, &addr, 1);
-            else
-                  ret_buf = process_file("/proc/self/exe", &addr, 1);
-            locations[x] = ret_buf;
-            total += strlen(ret_buf[0]) + 1;
-      }
-      pthread_mutex_unlock(&bfd_mutex);
+    pthread_mutex_lock(&bfd_mutex);
+    bfd_init();
+    for (x = stack_depth, y = 0; x >= 0; x--, y++) {
+        struct file_match match = {.address = buffer[x]};
+        char **ret_buf;
+        bfd_vma addr;
+        dl_iterate_phdr(find_matching_file, &match);
+        addr = buffer[x] - match.base;
+        if (match.file && strlen(match.file))
+            ret_buf = process_file(match.file, &addr, 1);
+        else
+            ret_buf = process_file("/proc/self/exe", &addr, 1);
+        locations[x] = ret_buf;
+        total += strlen(ret_buf[0]) + 1;
+    }
+    pthread_mutex_unlock(&bfd_mutex);
 
-      /* allocate the array of char* we are going to return and extra space for
-       * all of the strings */
-      final = malloc(total + (stack_depth + 1) * sizeof(char*));
-      /* get a pointer to the extra space */
-      f_strings = (char*)(final + stack_depth + 1);
+    /* allocate the array of char* we are going to return and extra space for
+     * all of the strings */
+    final = malloc(total + (stack_depth + 1) * sizeof(char *));
+    /* get a pointer to the extra space */
+    f_strings = (char *)(final + stack_depth + 1);
 
-      /* fill in all of strings and pointers */
-      for (x=stack_depth; x>=0; x--) {
-            strcpy(f_strings, locations[x][0]);
-            free(locations[x]);
-            final[x] = f_strings;
-            f_strings += strlen(f_strings) + 1;
-      }
+    /* fill in all of strings and pointers */
+    for (x = stack_depth; x >= 0; x--) {
+        strcpy(f_strings, locations[x][0]);
+        free(locations[x]);
+        final[x] = f_strings;
+        f_strings += strlen(f_strings) + 1;
+    }
 
-      free(locations);
+    free(locations);
 
-      return final;
+    return final;
 }
 
-void
-oc_backtrace_symbols_fd(void *const *buffer, int size, int fd)
+void oc_backtrace_symbols_fd(void *const *buffer, int size, int fd)
 {
-      int j;
-      char **strings;
+    int j;
+    char **strings;
 
-      strings = backtrace_symbols(buffer, size);
-      if (strings == NULL) {
-            perror("backtrace_symbols");
-            exit(EXIT_FAILURE);
-      }
+    strings = backtrace_symbols(buffer, size);
+    if (strings == NULL) {
+        perror("backtrace_symbols");
+        exit(EXIT_FAILURE);
+    }
 
-      for (j = 0; j < size; j++)
-            dprintf(fd, "%s\n", strings[j]);
+    for (j = 0; j < size; j++)
+        dprintf(fd, "%s\n", strings[j]);
 
-      free(strings);
+    free(strings);
 }
 
 #endif // defined(HAVE_BFD) && defined(HAVE_IBERTY)

--- a/opencog/util/backtrace-symbols.c
+++ b/opencog/util/backtrace-symbols.c
@@ -115,9 +115,9 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
 
     if (spot->found) return;
 
-    if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0) return;
+    if ((bfd_section_flags(section) & SEC_ALLOC) == 0) return;
 
-    vma = bfd_get_section_vma(abfd, section);
+    vma = bfd_section_vma(section);
     if (spot->pc < vma) return;
 
     size = bfd_section_size(section);


### PR DESCRIPTION
This is one of the three opened pull requests opened among OpenCog projects that changes and fixes a few scripts such that you can build and use OpenCog on the new LTS Ubuntu 20.04, coming out this April.

Unfortunately, there is a small fix that I had to apply to Cogutil, so these changes **are not** backwards-compatible.

What changed here is that a few procedures (namely `bfd_get_section_vma`, `bfd_get_section_flags` and `bfd_section_size`) changed their names and/or signature.

Sorry for the reformatting, I couldn't get clang-format to output the same style.

Again, this is not backwards-compatible so I'm just leaving this here in case some day you want to move to 20.04 so perhaps this will save you time.