### PR TITLE
If queue is closed, then grab everything in queue.

### DIFF
--- a/opencog/util/concurrent_queue.h
+++ b/opencog/util/concurrent_queue.h
@@ -187,7 +187,7 @@ public:
             {
                 the_cond.wait(lock);
             }
-            if (is_canceled) throw Canceled();
+            if (is_canceled) break;
         }
         while (the_queue.empty());
 

--- a/opencog/util/concurrent_set.h
+++ b/opencog/util/concurrent_set.h
@@ -200,7 +200,7 @@ public:
             {
                 the_cond.wait(lock);
             }
-            if (is_canceled) throw Canceled();
+            if (is_canceled) break;
         }
         while (the_set.empty());
 

--- a/opencog/util/concurrent_stack.h
+++ b/opencog/util/concurrent_stack.h
@@ -186,7 +186,7 @@ public:
             {
                 the_cond.wait(lock);
             }
-            if (is_canceled) throw Canceled();
+            if (is_canceled) break;
         }
         while (the_stack.empty());
 


### PR DESCRIPTION
Unlike the pop() variants, this is capable of returning an empty set.
Therefore, it does not need to throw.