### PR TITLE
Fix breakage with Binutil 2.35 (#236)

### DIFF
--- a/opencog/util/backtrace-symbols.c
+++ b/opencog/util/backtrace-symbols.c
@@ -115,7 +115,7 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
 
     if (spot->found) return;
 
-#ifdef bfd_section_flags
+#ifndef bfd_get_section_flags
     #define NEW_BFD_API 1
 #endif
 #ifdef NEW_BFD_API


### PR DESCRIPTION
Seems "#ifdef bfd_section_flags" doesn't work anymore with Binutils 2.35.  "#ifndef bfd_get_section_flags" should work.