### PR TITLE
Build works on my machine now with these changes

### DIFF
--- a/opencog/util/backtrace-symbols.c
+++ b/opencog/util/backtrace-symbols.c
@@ -127,13 +127,7 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
     size = bfd_section_size(section);
     if (spot->pc >= vma + size) return;
 #else
-    if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0) return;
 
-    vma = bfd_get_section_vma(abfd, section);
-    if (spot->pc < vma) return;
-
-    size = bfd_section_size(abfd, section);
-    if (spot->pc >= vma + size) return;
 #endif
     spot->found = bfd_find_nearest_line(abfd, section, spot->syms, spot->pc - vma,
                                         &(spot->filename), &(spot->functionname), &(spot->line));


### PR DESCRIPTION
Before when I tried to build, I would get these errors:

Scanning dependencies of target cogutil
[  5%] Building C object opencog/util/CMakeFiles/cogutil.dir/backtrace-symbols.c.o
/home/matt/OPENCOG/cogutil/opencog/util/backtrace-symbols.c: In function ‘find_address_in_section’:
/home/matt/OPENCOG/cogutil/opencog/util/backtrace-symbols.c:130:10: warning: implicit declaration of function ‘bfd_get_section_flags’; did you mean ‘bfd_set_section_flags’? [-Wimplicit-function-declaration]
  130 |     if ((bfd_get_section_flags(abfd) & SEC_ALLOC) == 0) return;
      |          ^~~~~~~~~~~~~~~~~~~~~
      |          bfd_set_section_flags
/home/matt/OPENCOG/cogutil/opencog/util/backtrace-symbols.c:132:11: warning: implicit declaration of function ‘bfd_get_section_vma’; did you mean ‘bfd_set_section_vma’? [-Wimplicit-function-declaration]
  132 |     vma = bfd_get_section_vma(abfd, section);
      |           ^~~~~~~~~~~~~~~~~~~
      |           bfd_set_section_vma
/home/matt/OPENCOG/cogutil/opencog/util/backtrace-symbols.c:135:29: warning: passing argument 1 of ‘bfd_section_size’ from incompatible pointer type [-Wincompatible-pointer-types]
  135 |     size = bfd_section_size(abfd, section);
      |                             ^~~~
      |                             |
      |                             bfd * {aka struct bfd *}
In file included from /home/matt/OPENCOG/cogutil/opencog/util/backtrace-symbols.c:73:
/usr/include/bfd.h:1206:35: note: expected ‘const asection *’ {aka ‘const struct bfd_section *’} but argument is of type ‘bfd *’ {aka ‘struct bfd *’}
 1206 | bfd_section_size (const asection *sec)
      |                   ~~~~~~~~~~~~~~~~^~~
/home/matt/OPENCOG/cogutil/opencog/util/backtrace-symbols.c:135:12: error: too many arguments to function ‘bfd_section_size’
  135 |     size = bfd_section_size(abfd, section);
      |            ^~~~~~~~~~~~~~~~
In file included from /home/matt/OPENCOG/cogutil/opencog/util/backtrace-symbols.c:73:
/usr/include/bfd.h:1206:1: note: declared here
 1206 | bfd_section_size (const asection *sec)
      | ^~~~~~~~~~~~~~~~
make[2]: *** [opencog/util/CMakeFiles/cogutil.dir/build.make:76: opencog/util/CMakeFiles/cogutil.dir/backtrace-symbols.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:368: opencog/util/CMakeFiles/cogutil.dir/all] Error 2
make: *** [Makefile:152: all] Error 2


By deleting this lines the build worked with 100% success. Maybe this was just something unique to machine, or there's probably a better solution, so up to you if you want to actually commit the changes.