### PR TITLE
Fix boost compile error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,10 +100,10 @@ ENDIF (CYGWIN)
 SET(Boost_USE_STATIC_LIBS OFF)
 SET(Boost_USE_MULTITHREADED ON)
 # The minimum boost version required for building.
-SET(MIN_BOOST 1.46)
+SET(MIN_BOOST 1.60)
 
 # Required boost packages
-# 1.46 is minimum for required filesystem support
+# 1.60 is minimum for required filesystem support
 FIND_PACKAGE(Boost ${MIN_BOOST} COMPONENTS filesystem program_options system thread REQUIRED)
 
 IF (Boost_FOUND)

--- a/opencog/util/algorithm.h
+++ b/opencog/util/algorithm.h
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <set>
 #include <boost/lexical_cast.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <algorithm>
 
@@ -274,6 +274,8 @@ Set set_symmetric_difference(const Set& s1, const Set& s2) {
 template<typename It, typename Pred, typename Out>
 Out n_way_partition(It begin, It end, const Pred p, int n, Out out)
 {
+	using namespace boost::placeholders;
+
 	// could be made more efficient if needed
 	for (int i = 0;i < n - 1;++i)
 		*out++ = begin = std::partition(begin, end, boost::bind(p, _1) == i);


### PR DESCRIPTION
Explicitly use `boost::placeholders` in order to compile under boost 1.75. Alternatively I could have silenced the error, but this will likely be mandatory at some point so better do it right now. It requires to upgrade boost requirement to boost 1.60, which is 5 year old, so I think it is more than acceptable.