### PR TITLE
We need to install asmoses before running the unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,6 +403,10 @@ jobs:
       - run:
           name: Build
           command: cd build && make
+      # Temporary fix: install asmoses to please the unit tests
+      - run:
+          name: Install
+          command: cd build && make install
       - run:
           name: Build tests
           command: cd build && make tests


### PR DESCRIPTION
Ideally we should not need that but for some reason escaping my
understanding we do.