### PR TITLE
Fix guile finder

### DIFF
--- a/cmake/FindGuile.cmake
+++ b/cmake/FindGuile.cmake
@@ -32,6 +32,7 @@ FIND_PATH(GUILE_INCLUDE_DIR libguile.h
 
 	/usr/include
 	/usr/local/include
+	NO_DEFAULT_PATH
 )
 
 # Look for the library


### PR DESCRIPTION
I have a `libguile.h` under `/usr/include`, which belongs to 1.8.8 version of guile. In this case, `NO_DEFAULT_PATH` needs to be set for it to find the correct header file under `/usr/include/guile/3.0`.