### PR TITLE
std::unary_function is deprecated in c++17

### DIFF
--- a/opencog/util/misc.h
+++ b/opencog/util/misc.h
@@ -69,7 +69,7 @@ void tokenize(const std::string& str,
 }
 
 template<typename _T>
-struct safe_deleter : public std::unary_function<_T*&, void>
+struct safe_deleter
 {
     void operator()(_T*& __ptr) {
         if (__ptr) {


### PR DESCRIPTION
It has been removed, and generates warning messages.