### PR TITLE
Use after free

### DIFF
--- a/opencog/util/tree.cc
+++ b/opencog/util/tree.cc
@@ -123,7 +123,9 @@ std::istream& operator>>(std::istream& in, opencog::tree<std::string>& t)
     TreeGrammar tg;
     tr.clear();
     at = tr.begin();
-    parse(str.c_str(), tg, space_p);
+
+    // The line below results in a use-after-free compiler error.
+    // parse(str.c_str(), tg, space_p);
 
     t = tr;
     tr.clear();


### PR DESCRIPTION
Sub out code that is causing a compiler warning of use-after-free.
Only moses/asmoses uses this code. It appears to be bit-rotted.