### PR TITLE
Get ready to remove CMake CMP00037 backwards compat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: cd build && make tests
       - run:
           name: Run tests
-          command: cd build && make test ARGS="$MAKEFLAGS"
+          command: cd build && make check ARGS="$MAKEFLAGS"
       - run:
           name: Print test log
           command: cat build/tests/Testing/Temporary/LastTest.log
@@ -201,7 +201,7 @@ jobs:
           command: cd build && make tests
       - run:
           name: Run tests
-          command: cd build && make test ARGS="$MAKEFLAGS"
+          command: cd build && make check ARGS="$MAKEFLAGS"
       - run:
           name: Install Attention
           command: cd build && make install && ldconfig
@@ -248,7 +248,7 @@ jobs:
           command: cd build && make tests
       - run:
           name: Run tests
-          command: cd build && make test ARGS="$MAKEFLAGS"
+          command: cd build && make check ARGS="$MAKEFLAGS"
       - run:
           name: Install Unify
           command: cd build && make install && ldconfig
@@ -298,7 +298,7 @@ jobs:
           command: cd build && make tests
       - run:
           name: Run tests
-          command: cd build && make test ARGS="$MAKEFLAGS"
+          command: cd build && make check ARGS="$MAKEFLAGS"
       - run:
           name: Install URE
           command: cd build && make install && ldconfig
@@ -359,7 +359,7 @@ jobs:
           command: cd build && make tests
       - run:
           name: Run tests
-          command: cd build && make test ARGS="$MAKEFLAGS"
+          command: cd build && make check ARGS="$MAKEFLAGS"
       - run:
           name: Install Miner
           command: cd build && make install && ldconfig
@@ -416,7 +416,7 @@ jobs:
           command: cd build && make tests
       - run:
           name: Run tests
-          command: cd build && make test ARGS="$MAKEFLAGS"
+          command: cd build && make check ARGS="$MAKEFLAGS"
       - run:
           name: Print test log
           command: cat build/tests/Testing/Temporary/LastTest.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ IF (CXXTEST_FOUND)
 	ADD_SUBDIRECTORY(tests EXCLUDE_FROM_ALL)
 	IF (CMAKE_BUILD_TYPE STREQUAL "Coverage")
 		# doing coverage stuff while running tests if this is the Coverage build
-		ADD_CUSTOM_TARGET(test
+		ADD_CUSTOM_TARGET(check
 			# TODO lcov should be found by cmake first
 			# TODO set it up so that we can pick to run coverage per test, or
 			# combined across all tests (the latter is MUCH faster). Use a define?
@@ -250,13 +250,18 @@ IF (CXXTEST_FOUND)
 		)
 	ELSE (CMAKE_BUILD_TYPE STREQUAL "Coverage")
 		# If this is a build with coverage enabled then test normally
-		ADD_CUSTOM_TARGET(test
+		ADD_CUSTOM_TARGET(check
 			DEPENDS tests
 			WORKING_DIRECTORY tests
 			COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process $(ARGS)
 			COMMENT "Running tests..."
 		)
 	ENDIF (CMAKE_BUILD_TYPE STREQUAL "Coverage")
+
+	# When CMP00037 is finally turned off, just remove these two lines.
+	ADD_CUSTOM_TARGET(test)
+	ADD_DEPENDENCIES(test check)
+
 ENDIF (CXXTEST_FOUND)
 
 ADD_CUSTOM_TARGET(cscope


### PR DESCRIPTION
After this, it should be safe to to kill CMP00037 testing