### PR TITLE
Parametrising location of ld.so.conf files.

### DIFF
--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -5,4 +5,5 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/opencog.conf
 	"${CMAKE_INSTALL_PREFIX}/lib${LIB_DIR_SUFFIX}/opencog\n")
 
 # Well, this isn't portable, but it works for Linux
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/opencog.conf DESTINATION "/etc/ld.so.conf.d")
+set(CMAKE_CONF_PREFIX "/etc" CACHE PATH "Directory for configuration files")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/opencog.conf DESTINATION "${CMAKE_CONF_PREFIX}/ld.so.conf.d")


### PR DESCRIPTION
Currently, the installation of ld.so.conf file related to cogutil occurs in /etc. This is not only not portable, as mentionned in the cmake file where this is defined, but moreover requires root privileges. The current PR allows to use -DCMAKE_CONF_PREFIX=/home/mini-me/.config to ensure that this file is deployed locally in somewhere else than /etc. This behaviour is not standard, and these files are not picked up by default. A bit of shell scripting can however make that happen and allow to installation of cogutils to work in userspace without root privileges.

Some script like that in a shell initialisation should do the trick:

```bash
if [[ -d ~/.config/ld.so.conf.d ]]; then
    for conf in ~/.config/ld.so.conf.d/*.conf; do
        export LD_LIBRARY_PATH=$(cat "$conf" | tr '\n' ':')$LD_LIBRARY_PATH
    done
fi
```

It is unclear, however, to me, whether such a snippet is currently necessary for installation of opencog on top of cogutil.